### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,0 +1,33 @@
+name: Continuous Integration
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+      branches:
+          - main
+  workflow_dispatch:
+
+jobs:
+    build-and-test:
+        runs-on: ubuntu-latest
+
+        steps:
+          - name: Checkout code
+            uses: actions/checkout@v4
+
+          - name: Setup Go
+            uses: actions/setup-go@v2
+            with:
+              go-version: 1.23
+              cache-dependency-path: subdir/go.sum
+
+          - name: Install dependencies
+            run: go get .
+
+          - name: Build project
+            run: go build -v ./...
+
+          - name: Run tests
+            run: go test -v ./... -cover


### PR DESCRIPTION
This pull request introduces a new continuous integration (CI) workflow to the repository. The workflow is designed to automate the build and test processes for pull requests and pushes to the main branch.

Key changes include:

* Created a new CI workflow named `Continuous Integration` in `.github/workflows/continuous-integration.yaml`.
* Configured the workflow to trigger on pull requests and pushes to the main branch, as well as manual dispatches.
* Added a job `build-and-test` that runs on `ubuntu-latest` and includes the following steps:
  * Checkout code using `actions/checkout@v4`.
  * Setup Go environment using `actions/setup-go@v2` with Go version 1.23 and cache dependencies.
  * Install project dependencies using `go get .`.
  * Build the project using `go build -v ./...`.
  * Run tests with coverage using `go test -v ./... -cover`.