### PR TITLE
Refactor to return custom Database errors incase database operation fails

### DIFF
--- a/_test/db_mock.go
+++ b/_test/db_mock.go
@@ -1,9 +1,9 @@
 package test
 
 import (
-	"errors"
 	"reflect"
 	"the-wedding-game-api/db"
+	apperrors "the-wedding-game-api/errors"
 )
 
 type MockDB struct {
@@ -18,13 +18,13 @@ func (m *MockDB) Where(_ interface{}, _ ...interface{}) db.DatabaseInterface {
 func (m *MockDB) First(dest interface{}, _ ...interface{}) db.DatabaseInterface {
 	if len(m.items) == 0 {
 		destValue := reflect.ValueOf(dest)
-		m.Error = errors.New("record not found: " + destValue.Type().String())
+		m.Error = apperrors.NewRecordNotFoundError("record not found: " + destValue.Type().String())
 		return m
 	}
 
 	destValue := reflect.ValueOf(dest)
 	if destValue.Kind() != reflect.Ptr || destValue.IsNil() {
-		m.Error = errors.New("dest must be a non-nil pointer")
+		m.Error = apperrors.NewDatabaseError("dest must be a non-nil pointer")
 		return m
 	}
 
@@ -46,12 +46,12 @@ func (m *MockDB) Create(value interface{}) db.DatabaseInterface {
 func (m *MockDB) Find(dest interface{}, _ ...interface{}) db.DatabaseInterface {
 	destValue := reflect.ValueOf(dest)
 	if destValue.Kind() != reflect.Ptr || destValue.IsNil() {
-		m.Error = errors.New("dest must be a non-nil pointer")
+		m.Error = apperrors.NewDatabaseError("dest must be a non-nil pointer")
 		return m
 	}
 
 	if destValue.Elem().Kind() != reflect.Slice {
-		m.Error = errors.New("dest must be a pointer to a slice")
+		m.Error = apperrors.NewDatabaseError("dest must be a pointer to a slice")
 		return m
 	}
 

--- a/db/gorm_db.go
+++ b/db/gorm_db.go
@@ -6,6 +6,7 @@ import (
 	_ "github.com/lib/pq"
 	"log"
 	"os"
+	apperrors "the-wedding-game-api/errors"
 )
 
 type database struct {
@@ -33,7 +34,16 @@ func (p *database) Find(dest interface{}, where ...interface{}) DatabaseInterfac
 }
 
 func (p *database) GetError() error {
-	return p.db.Error
+	err := p.db.Error
+	if err == nil {
+		return nil
+	}
+
+	if gorm.IsRecordNotFoundError(err) {
+		return apperrors.NewRecordNotFoundError(err.Error())
+	}
+
+	return apperrors.NewDatabaseError(err.Error())
 }
 
 func newDatabase() DatabaseInterface {

--- a/errors/database_error.go
+++ b/errors/database_error.go
@@ -1,0 +1,25 @@
+package apperrors
+
+import "errors"
+
+type DatabaseError struct {
+	code    string
+	Message string
+}
+
+func (e DatabaseError) Error() string {
+	return e.Message
+}
+
+func NewDatabaseError(message string) DatabaseError {
+	return DatabaseError{
+		code:    "DatabaseError",
+		Message: message,
+	}
+}
+
+func IsDatabaseError(err error) bool {
+	var databaseError DatabaseError
+	ok := errors.As(err, &databaseError)
+	return ok
+}

--- a/errors/database_error_test.go
+++ b/errors/database_error_test.go
@@ -1,0 +1,58 @@
+package apperrors
+
+import "testing"
+
+func TestNewDatabaseError(t *testing.T) {
+	databaseError := NewDatabaseError("database error")
+	if databaseError.Message != "database error" {
+		t.Errorf("expected database error but got %s", databaseError.Message)
+	}
+	if databaseError.code != "DatabaseError" {
+		t.Errorf("expected DatabaseError but got %s", databaseError.code)
+	}
+	if !IsDatabaseError(databaseError) {
+		t.Errorf("expected true but got false")
+	}
+
+	databaseError = NewDatabaseError("hello there")
+	if databaseError.Message != "hello there" {
+		t.Errorf("expected hello there but got %s", databaseError.Message)
+	}
+	if databaseError.code != "DatabaseError" {
+		t.Errorf("expected DatabaseError but got %s", databaseError.code)
+	}
+	if !IsDatabaseError(databaseError) {
+		t.Errorf("expected true but got false")
+	}
+}
+
+func TestDatabaseErrorMessage(t *testing.T) {
+	databaseError := NewDatabaseError("hello there")
+	if databaseError.Error() != "hello there" {
+		t.Errorf("expected hello there but got %s", databaseError.Error())
+	}
+
+	databaseError = NewDatabaseError("random message")
+	if databaseError.Error() != "random message" {
+		t.Errorf("expected database error but got %s", databaseError.Error())
+	}
+}
+
+func TestIsDatabaseError(t *testing.T) {
+	databaseError := NewDatabaseError("hello there")
+	if !IsDatabaseError(databaseError) {
+		t.Errorf("expected true but got false")
+	}
+
+	databaseError = NewDatabaseError("random message")
+	if !IsDatabaseError(databaseError) {
+		t.Errorf("expected true but got false")
+	}
+}
+
+func TestIsDatabaseErrorNegative(t *testing.T) {
+	authorizationError := NewAuthorizationError()
+	if IsDatabaseError(authorizationError) {
+		t.Errorf("expected false but got true")
+	}
+}

--- a/errors/record_not_found_error.go
+++ b/errors/record_not_found_error.go
@@ -1,0 +1,25 @@
+package apperrors
+
+import "errors"
+
+type RecordNotFoundError struct {
+	code    string
+	Message string
+}
+
+func (e RecordNotFoundError) Error() string {
+	return e.Message
+}
+
+func NewRecordNotFoundError(message string) RecordNotFoundError {
+	return RecordNotFoundError{
+		code:    "RecordNotFoundError",
+		Message: message,
+	}
+}
+
+func IsRecordNotFoundError(err error) bool {
+	var recordNotFoundError RecordNotFoundError
+	ok := errors.As(err, &recordNotFoundError)
+	return ok
+}

--- a/errors/record_not_found_error_test.go
+++ b/errors/record_not_found_error_test.go
@@ -1,0 +1,58 @@
+package apperrors
+
+import "testing"
+
+func TestNewRecordNotFoundError(t *testing.T) {
+	recordNotFoundError := NewRecordNotFoundError("record not found")
+	if recordNotFoundError.Message != "record not found" {
+		t.Errorf("expected record not found but got %s", recordNotFoundError.Message)
+	}
+	if recordNotFoundError.code != "RecordNotFoundError" {
+		t.Errorf("expected RecordNotFoundError but got %s", recordNotFoundError.code)
+	}
+	if !IsRecordNotFoundError(recordNotFoundError) {
+		t.Errorf("expected true but got false")
+	}
+
+	recordNotFoundError = NewRecordNotFoundError("hello there")
+	if recordNotFoundError.Message != "hello there" {
+		t.Errorf("expected hello there but got %s", recordNotFoundError.Message)
+	}
+	if recordNotFoundError.code != "RecordNotFoundError" {
+		t.Errorf("expected RecordNotFoundError but got %s", recordNotFoundError.code)
+	}
+	if !IsRecordNotFoundError(recordNotFoundError) {
+		t.Errorf("expected true but got false")
+	}
+}
+
+func TestRecordNotFoundErrorMessage(t *testing.T) {
+	recordNotFoundError := NewRecordNotFoundError("hello there")
+	if recordNotFoundError.Error() != "hello there" {
+		t.Errorf("expected hello there but got %s", recordNotFoundError.Error())
+	}
+
+	recordNotFoundError = NewRecordNotFoundError("random message")
+	if recordNotFoundError.Error() != "random message" {
+		t.Errorf("expected record not found but got %s", recordNotFoundError.Error())
+	}
+}
+
+func TestIsRecordNotFoundError(t *testing.T) {
+	recordNotFoundError := NewRecordNotFoundError("hello there")
+	if !IsRecordNotFoundError(recordNotFoundError) {
+		t.Errorf("expected true but got false")
+	}
+
+	recordNotFoundError = NewRecordNotFoundError("random message")
+	if !IsRecordNotFoundError(recordNotFoundError) {
+		t.Errorf("expected true but got false")
+	}
+}
+
+func TestIsRecordNotFoundErrorNegative(t *testing.T) {
+	authorizationError := NewAuthorizationError()
+	if IsRecordNotFoundError(authorizationError) {
+		t.Errorf("expected false but got true")
+	}
+}

--- a/models/access_tokens.go
+++ b/models/access_tokens.go
@@ -3,6 +3,7 @@ package models
 import (
 	"github.com/google/uuid"
 	"github.com/jinzhu/gorm"
+	"strconv"
 	"the-wedding-game-api/db"
 	apperrors "the-wedding-game-api/errors"
 	"time"
@@ -34,7 +35,7 @@ func GetUserByAccessToken(token string) (User, error) {
 	conn := db.GetConnection()
 	var accessToken AccessToken
 	if err := conn.Where("token = ?", token).First(&accessToken).GetError(); err != nil {
-		if gorm.IsRecordNotFoundError(err) {
+		if apperrors.IsRecordNotFoundError(err) {
 			return User{}, apperrors.NewAccessTokenNotFoundError()
 		}
 		return User{}, err
@@ -42,6 +43,9 @@ func GetUserByAccessToken(token string) (User, error) {
 
 	var user User
 	if err := conn.Where("id = ?", accessToken.UserID).First(&user).GetError(); err != nil {
+		if apperrors.IsRecordNotFoundError(err) {
+			return User{}, apperrors.NewNotFoundError("User", strconv.Itoa(int(accessToken.UserID)))
+		}
 		return User{}, err
 	}
 

--- a/models/access_tokens_test.go
+++ b/models/access_tokens_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	test "the-wedding-game-api/_test"
 	"the-wedding-game-api/db"
+	apperrors "the-wedding-game-api/errors"
 	"time"
 )
 
@@ -55,6 +56,9 @@ func TestLinkAccessTokenToUserNegative(t *testing.T) {
 		return
 	}
 
+	if !apperrors.IsDatabaseError(err) {
+		t.Errorf("expected database error but got %s", err.Error())
+	}
 	if err.Error() != "test_error" {
 		t.Errorf("expected error but got %s", err.Error())
 	}
@@ -85,8 +89,11 @@ func TestGetUserByAccessTokenNotFound(t *testing.T) {
 		return
 	}
 
-	if err.Error() != "record not found: *models.AccessToken" {
-		t.Errorf("expected record not found: *models.AccessToken but got %s", err.Error())
+	if !apperrors.IsAccessTokenNotFoundError(err) {
+		t.Errorf("expected access token not found error but got %s", err.Error())
+	}
+	if err.Error() != "access token not found" {
+		t.Errorf("expected access token not found but got %s", err.Error())
 	}
 }
 
@@ -100,7 +107,10 @@ func TestGetUserByAccessTokenUserNotFound(t *testing.T) {
 		return
 	}
 
-	if err.Error() != "record not found: *models.User" {
-		t.Errorf("expected record not found: *models.User but got %s", err.Error())
+	if !apperrors.IsNotFoundError(err) {
+		t.Errorf("expected not found error but got %s", err.Error())
+	}
+	if err.Error() != "User with key 1 not found." {
+		t.Errorf("expected User with key 1 not found. but got %s", err.Error())
 	}
 }

--- a/models/answers.go
+++ b/models/answers.go
@@ -36,7 +36,7 @@ func VerifyAnswer(challengeId uint, answer string) (bool, error) {
 
 	err := conn.Where("challenge_id = ?", challengeId).First(&answerModel).GetError()
 	if err != nil {
-		if gorm.IsRecordNotFoundError(err) {
+		if apperrors.IsRecordNotFoundError(err) {
 			return false, apperrors.NewNotFoundError("Challenge", strconv.Itoa(int(challengeId)))
 		}
 		return false, err

--- a/models/answers_test.go
+++ b/models/answers_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	test "the-wedding-game-api/_test"
 	"the-wedding-game-api/db"
+	apperrors "the-wedding-game-api/errors"
 )
 
 var (
@@ -74,6 +75,9 @@ func TestAnswerSaveNegative(t *testing.T) {
 		return
 	}
 
+	if !apperrors.IsDatabaseError(err) {
+		t.Errorf("expected true but got false")
+	}
 	if err.Error() != "test_error" {
 		t.Errorf("expected test_error but got %s", err.Error())
 	}
@@ -118,7 +122,10 @@ func TestVerifyAnswerNotFound(t *testing.T) {
 		return
 	}
 
-	if err.Error() != "record not found: *models.Answer" {
-		t.Errorf("expected record not found: *models.Answer but got %s", err.Error())
+	if !apperrors.IsNotFoundError(err) {
+		t.Errorf("expected not found error but got %s", err.Error())
+	}
+	if err.Error() != "Challenge with key 123 not found." {
+		t.Errorf("expected Challenge with key 123 not found. but got %s", err.Error())
 	}
 }

--- a/models/auth.go
+++ b/models/auth.go
@@ -3,6 +3,7 @@ package models
 import (
 	"github.com/jinzhu/gorm"
 	"the-wedding-game-api/db"
+	apperrors "the-wedding-game-api/errors"
 	"the-wedding-game-api/types"
 )
 
@@ -23,7 +24,7 @@ func DoesUserExist(username string) (bool, User, error) {
 	var user User
 	conn := db.GetConnection()
 	if err := conn.Where("username = ?", username).First(&user).GetError(); err != nil {
-		if gorm.IsRecordNotFoundError(err) {
+		if apperrors.IsRecordNotFoundError(err) {
 			return false, User{}, nil
 		}
 		return false, User{}, err

--- a/models/auth_test.go
+++ b/models/auth_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	test "the-wedding-game-api/_test"
 	"the-wedding-game-api/db"
+	apperrors "the-wedding-game-api/errors"
 	"the-wedding-game-api/types"
 )
 
@@ -56,14 +57,11 @@ func TestDoesUserExistNotFound(t *testing.T) {
 	test.SetupMockDb()
 
 	exists, _, err := DoesUserExist(testUserAdmin.Username)
-	if err == nil {
-		t.Errorf("expected error but got nil")
+	if err != nil {
+		t.Errorf("expected nil but got %s", err.Error())
 		return
 	}
 
-	if err.Error() != "record not found: *models.User" {
-		t.Errorf("expected record not found: *models.User but got %s", err.Error())
-	}
 	if exists {
 		t.Errorf("expected false but got true")
 	}
@@ -80,6 +78,9 @@ func TestDoesUserExistError(t *testing.T) {
 		return
 	}
 
+	if !apperrors.IsDatabaseError(err) {
+		t.Errorf("expected true but got false")
+	}
 	if err.Error() != "test_error" {
 		t.Errorf("expected test_error but got %s", err.Error())
 	}
@@ -131,6 +132,9 @@ func TestUserSaveError(t *testing.T) {
 		return
 	}
 
+	if !apperrors.IsDatabaseError(err) {
+		t.Errorf("expected true but got false")
+	}
 	if err.Error() != "test_error" {
 		t.Errorf("expected test_error but got %s", err.Error())
 	}

--- a/models/challenges.go
+++ b/models/challenges.go
@@ -81,7 +81,7 @@ func GetChallengeByID(id uint) (Challenge, error) {
 	conn := db.GetConnection()
 	var challenge Challenge
 	if err := conn.First(&challenge, id).GetError(); err != nil {
-		if gorm.IsRecordNotFoundError(err) {
+		if apperrors.IsRecordNotFoundError(err) {
 			return Challenge{}, apperrors.NewNotFoundError("Challenge", strconv.Itoa(int(id)))
 		}
 		return Challenge{}, err

--- a/models/challenges_test.go
+++ b/models/challenges_test.go
@@ -440,7 +440,7 @@ func TestGetChallengeByIDNotFound(t *testing.T) {
 		return
 	}
 
-	if err.Error() != "record not found: *models.Challenge" {
-		t.Errorf("expected record not found: *models.Challenge but got %s", err.Error())
+	if err.Error() != "Challenge with key 1 not found." {
+		t.Errorf("expected Challenge with key 1 not found. but got %s", err.Error())
 	}
 }

--- a/models/submissions.go
+++ b/models/submissions.go
@@ -3,6 +3,7 @@ package models
 import (
 	"github.com/jinzhu/gorm"
 	"the-wedding-game-api/db"
+	apperrors "the-wedding-game-api/errors"
 )
 
 type Submission struct {
@@ -31,13 +32,12 @@ func (s *Submission) Save() (*Submission, error) {
 	return s, nil
 }
 
-// TODO: replace all instances of `gorm.IsRecordNotFoundError` with custom error type
 func IsChallengeCompleted(userId uint, challengeId uint) (bool, error) {
 	conn := db.GetConnection()
 	var submission Submission
 	err := conn.Where("user_id = ? AND challenge_id = ?", userId, challengeId).First(&submission).GetError()
 	if err != nil {
-		if gorm.IsRecordNotFoundError(err) {
+		if apperrors.IsRecordNotFoundError(err) {
 			return false, nil
 		}
 		return false, err

--- a/models/submissions_test.go
+++ b/models/submissions_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	test "the-wedding-game-api/_test"
 	"the-wedding-game-api/db"
+	apperrors "the-wedding-game-api/errors"
 )
 
 var (
@@ -78,6 +79,9 @@ func TestSubmissionSaveError(t *testing.T) {
 		t.Errorf("expected error but got nil")
 		return
 	}
+	if !apperrors.IsDatabaseError(err) {
+		t.Errorf("expected true but got false")
+	}
 	if err.Error() != "test_error" {
 		t.Errorf("expected test_error but got %s", err.Error())
 	}
@@ -104,13 +108,13 @@ func TestIsChallengeCompleted(t *testing.T) {
 func TestIsChallengeCompletedNotFound(t *testing.T) {
 	test.SetupMockDb()
 
-	_, err := IsChallengeCompleted(testSubmission1.UserId, testSubmission1.ChallengeID)
-	if err == nil {
-		t.Errorf("expected error but got nil")
+	isCompleted, err := IsChallengeCompleted(testSubmission1.UserId, testSubmission1.ChallengeID)
+	if err != nil {
+		t.Errorf("expected nil but got %v", err)
 		return
 	}
-	if err.Error() != "record not found: *models.Submission" {
-		t.Errorf("expected record not found: *models.Submission but got %s", err.Error())
+	if isCompleted {
+		t.Errorf("expected false but got true")
 	}
 }
 
@@ -128,6 +132,9 @@ func TestIsChallengeCompletedError(t *testing.T) {
 	if err == nil {
 		t.Errorf("expected error but got nil")
 		return
+	}
+	if !apperrors.IsDatabaseError(err) {
+		t.Errorf("expected true but got false")
 	}
 	if err.Error() != "test_error" {
 		t.Errorf("expected test_error but got %s", err.Error())


### PR DESCRIPTION
This pull request introduces custom error handling in the `the-wedding-game-api` project by replacing generic GORM errors with application-specific errors. The changes include the creation of new error types and updating various parts of the codebase to use these new error types.

Custom error handling improvements:

* [`errors/database_error.go`](diffhunk://#diff-f46965a6184f04fecf8cea1fb8087b83c971a268aec3b00e7f6dc6b2f78dc280R1-R25): Added a new `DatabaseError` type with methods to create and check for this error.
* [`errors/record_not_found_error.go`](diffhunk://#diff-607c133dd64dc5e340e21dd896374d6b5da6d9ce267f70356d3b4518417510efR1-R25): Added a new `RecordNotFoundError` type with methods to create and check for this error.

Updates to database interaction methods:

* [`db/gorm_db.go`](diffhunk://#diff-6eb68002c51ae19dfd465bf3999ebe16306d67a6dd5cab42c41e1094b62993ffL36-R46): Updated the `GetError` method to return custom errors instead of GORM errors.
* [`_test/db_mock.go`](diffhunk://#diff-2feab32e370d6fccd41c5cabd7ac61841d51f0f7e3b78c3e6552abdb3ca6c5faL73-R83): Modified the `GetError` method in the `MockDB` struct to return custom errors.

Refactoring model methods to use custom errors:

* [`models/access_tokens.go`](diffhunk://#diff-7d54b71040af2bfaea2ffca1f14e57193a707668f6af316bf192cefc562f2545L37-R48): Replaced `gorm.IsRecordNotFoundError` with `apperrors.IsRecordNotFoundError` and updated error handling in `GetUserByAccessToken`.
* [`models/answers.go`](diffhunk://#diff-0ec44b3620f43d713b5a6215c53b5a7bd6ae173f22e7ede01c18a37bde2286deL39-R39): Updated the `VerifyAnswer` method to use custom errors.
* [`models/auth.go`](diffhunk://#diff-02208732c971c8da8c3d11d0bcaa8a64650ef54e5d7b3fb87313c9f1c727587dL26-R27): Modified the `DoesUserExist` method to use custom errors.
* [`models/challenges.go`](diffhunk://#diff-88af38bcf1b8c13f717084571c39ed322341afbc5c28bcabd6a86f0db4723e6cL84-R84): Updated the `GetChallengeByID` method to use custom errors.
* [`models/submissions.go`](diffhunk://#diff-95d51159098b5ea99952f0428ea122e31c210ea5c5365da84bfd18fc6fc27aebL34-R40): Replaced `gorm.IsRecordNotFoundError` with `apperrors.IsRecordNotFoundError` in the `IsChallengeCompleted` method.

Updates to test cases:

* [`models/access_tokens_test.go`](diffhunk://#diff-432765f8ee180b2074cc3befce3d10b130551113c0dbf50889638b2b0cee9151R59-R61): Added checks for custom errors in various test cases. [[1]](diffhunk://#diff-432765f8ee180b2074cc3befce3d10b130551113c0dbf50889638b2b0cee9151R59-R61) [[2]](diffhunk://#diff-432765f8ee180b2074cc3befce3d10b130551113c0dbf50889638b2b0cee9151L88-R96) [[3]](diffhunk://#diff-432765f8ee180b2074cc3befce3d10b130551113c0dbf50889638b2b0cee9151L103-R114)
* [`models/answers_test.go`](diffhunk://#diff-f01729443bc53fbb3f286f885063a390849f5def3510abf328da225a2bb29dc7R78-R80): Added checks for custom errors in test cases. [[1]](diffhunk://#diff-f01729443bc53fbb3f286f885063a390849f5def3510abf328da225a2bb29dc7R78-R80) [[2]](diffhunk://#diff-f01729443bc53fbb3f286f885063a390849f5def3510abf328da225a2bb29dc7L121-R129)
* [`models/auth_test.go`](diffhunk://#diff-2593308c2893b9926cc8cc7c39d5ef72cfe47e76eb76683fed2d8a89983c7fe3L59-L66): Updated test cases to check for custom errors. [[1]](diffhunk://#diff-2593308c2893b9926cc8cc7c39d5ef72cfe47e76eb76683fed2d8a89983c7fe3L59-L66) [[2]](diffhunk://#diff-2593308c2893b9926cc8cc7c39d5ef72cfe47e76eb76683fed2d8a89983c7fe3R81-R83) [[3]](diffhunk://#diff-2593308c2893b9926cc8cc7c39d5ef72cfe47e76eb76683fed2d8a89983c7fe3R135-R137)
* [`models/submissions_test.go`](diffhunk://#diff-cf400ba2758af3e93b17085d7e19ee00d920ecb3051a604302a4ed043bfe2d05R82-R84): Modified test cases to check for custom errors. [[1]](diffhunk://#diff-cf400ba2758af3e93b17085d7e19ee00d920ecb3051a604302a4ed043bfe2d05R82-R84) [[2]](diffhunk://#diff-cf400ba2758af3e93b17085d7e19ee00d920ecb3051a604302a4ed043bfe2d05L107-R117) [[3]](diffhunk://#diff-cf400ba2758af3e93b17085d7e19ee00d920ecb3051a604302a4ed043bfe2d05R136-R138)