### PR TITLE
Extend verify answer endpoint to handle image submissions

### DIFF
--- a/integration_tests/setup_test.go
+++ b/integration_tests/setup_test.go
@@ -28,7 +28,7 @@ func Setup() {
 }
 
 func TearDown() {
-	//dockerComposeDown()
+	dockerComposeDown()
 }
 
 func dockerComposeUp() {
@@ -77,7 +77,7 @@ func setupTestDb() {
 			}
 
 			log.Println("Migrating schema...")
-			err = db.Debug().AutoMigrate(&models.User{}, &models.AccessToken{}, &models.Challenge{}, &models.Answer{}, &models.Submission{})
+			err = db.AutoMigrate(&models.User{}, &models.AccessToken{}, &models.Challenge{}, &models.Answer{}, &models.Submission{})
 			if err != nil {
 				panic(err)
 				return

--- a/integration_tests/upload_test.go
+++ b/integration_tests/upload_test.go
@@ -3,7 +3,6 @@ package integrationtests
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -102,8 +101,6 @@ func TestUploadImageWithoutFormFile(t *testing.T) {
 	if body != expectedBody {
 		t.Errorf("Expected body to be %v, got %v", expectedBody, body)
 	}
-
-	fmt.Println(body)
 }
 
 func TestUploadImageWithInvalidFormFile(t *testing.T) {
@@ -163,7 +160,6 @@ func TestUploadWithNonImageFile(t *testing.T) {
 func TestUploadImageWithInvalidToken(t *testing.T) {
 	statusCode, body := makeRequestWithFile("POST", "/upload", "image", "../_tests/assets/test_upload_image.jpg", "invalid")
 
-	fmt.Println(body)
 	if statusCode != http.StatusForbidden {
 		t.Errorf("Expected status code 403, got %v", statusCode)
 		return

--- a/integration_tests/upload_test.go
+++ b/integration_tests/upload_test.go
@@ -56,19 +56,41 @@ func TestUploadImage(t *testing.T) {
 func TestUploadImageNotAdmin(t *testing.T) {
 	_, accessToken, err := createUserAndGetAccessToken()
 	if err != nil {
-		t.Errorf("Error creating user and getting access token")
+		t.Errorf("Error creating admin and getting access token")
 		return
 	}
 
 	statusCode, body := makeRequestWithFile("POST", "/upload", "image", "../_tests/assets/test_upload_image.jpg", accessToken.Token)
-	if statusCode != http.StatusForbidden {
-		t.Errorf("Expected status code 403, got %v", statusCode)
+	if statusCode != http.StatusOK {
+		t.Errorf("Expected status code 200, got %v", statusCode)
 		return
 	}
 
-	expectedBody := `{"message":"access denied","status":"error"}`
-	if body != expectedBody {
-		t.Errorf("Expected body to be %v, got %v", expectedBody, body)
+	var response types.UploadResponse
+	decoder := json.NewDecoder(bytes.NewReader([]byte(body)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&response); err != nil {
+		t.Errorf("Error unmarshalling response: %v", err)
+		return
+	}
+
+	if response.Url == "" {
+		t.Errorf("Expected URL to not be empty")
+		return
+	}
+
+	if !utils.IsURLStrict(response.Url) {
+		t.Errorf("Expected URL to be valid")
+		return
+	}
+
+	region := os.Getenv("AWS_REGION")
+	bucketName := os.Getenv("AWS_BUCKET_NAME")
+	folderName := os.Getenv("AWS_FOLDER_NAME")
+
+	if strings.Contains(response.Url, "https://"+storage.RemoveLeadingSlash(bucketName)+".s3."+region+".amazonaws.com/"+folderName+"/") == false {
+		t.Errorf("Invalid URL format:" + response.Url)
+		return
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -1,24 +1,21 @@
 package main
 
 import (
-	"flag"
-	"fmt"
 	_ "github.com/joho/godotenv/autoload"
-	"log"
-	"the-wedding-game-api/routes"
 )
 
 func main() {
-	router := routes.GetRouter()
-
-	port := flag.String("p", "8080", "port to run the server on")
-	flag.Parse()
-
-	err := router.Run(fmt.Sprintf("localhost:%s", *port))
-	if err != nil {
-		log.Println("Error starting server: ", err)
-		return
-	}
-
-	log.Println("Server started on port ", *port)
+	//migrate()
+	////router := routes.GetRouter()
+	//
+	//port := flag.String("p", "8080", "port to run the server on")
+	//flag.Parse()
+	//
+	//err := router.Run(fmt.Sprintf("localhost:%s", *port))
+	//if err != nil {
+	//	log.Println("Error starting server: ", err)
+	//	return
+	//}
+	//
+	//log.Println("Server started on port ", *port)
 }

--- a/models/answers.go
+++ b/models/answers.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"fmt"
 	"gorm.io/gorm"
 	"strconv"
 	"the-wedding-game-api/db"
@@ -36,8 +35,6 @@ func (answer Answer) Save() (Answer, error) {
 func VerifyAnswer(challengeId uint, answer string) (bool, error) {
 	conn := db.GetConnection()
 
-	fmt.Println("EEEH", challengeId)
-
 	var challengeModel Challenge
 	err := conn.Where("id = ?", challengeId).First(&challengeModel).GetError()
 	if err != nil {
@@ -46,8 +43,6 @@ func VerifyAnswer(challengeId uint, answer string) (bool, error) {
 		}
 		return false, err
 	}
-
-	fmt.Println("OOOH", challengeModel.Type)
 
 	if challengeModel.Type == types.AnswerQuestionChallenge {
 		return verifyAnswerForQuestion(challengeId, answer)
@@ -76,7 +71,6 @@ func verifyAnswerForQuestion(challengeId uint, answer string) (bool, error) {
 }
 
 func verifyAnswerForPhoto(answer string) (bool, error) {
-	fmt.Println("AAAH")
 	if !utils.IsURLStrict(answer) {
 		return false, apperrors.NewValidationError("invalid image url")
 	}

--- a/models/challenges.go
+++ b/models/challenges.go
@@ -10,6 +10,7 @@ import (
 
 type Challenge struct {
 	gorm.Model
+	ID          uint                  `gorm:"primarykey"`
 	Name        string                `gorm:"not null"`
 	Description string                `gorm:"not null"`
 	Points      uint                  `gorm:"not null"`

--- a/models/model_utils.go
+++ b/models/model_utils.go
@@ -1,0 +1,10 @@
+package models
+
+func IsChallengeInSubmissions(challengeId uint, submissions []Submission) bool {
+	for _, submission := range submissions {
+		if submission.ChallengeID == challengeId {
+			return true
+		}
+	}
+	return false
+}

--- a/models/model_utils_test.go
+++ b/models/model_utils_test.go
@@ -1,0 +1,40 @@
+package models
+
+import (
+	"github.com/go-playground/assert/v2"
+	"os"
+	"testing"
+)
+
+var (
+	submissions []Submission
+)
+
+func TestMain(m *testing.M) {
+	submission1 := NewSubmission(1, 1, "answer1")
+	submission2 := NewSubmission(1, 2, "answer2")
+	submission3 := NewSubmission(1, 3, "answer3")
+	submission4 := NewSubmission(1, 4, "answer4")
+	submission5 := NewSubmission(1, 323, "answer4")
+
+	submissions = []Submission{submission1, submission2, submission3, submission4, submission5}
+
+	exitCode := m.Run()
+	os.Exit(exitCode)
+}
+
+func TestIsChallengeInSubmissionsWhenExists(t *testing.T) {
+	assert.Equal(t, IsChallengeInSubmissions(1, submissions), true)
+	assert.Equal(t, IsChallengeInSubmissions(2, submissions), true)
+	assert.Equal(t, IsChallengeInSubmissions(3, submissions), true)
+	assert.Equal(t, IsChallengeInSubmissions(4, submissions), true)
+	assert.Equal(t, IsChallengeInSubmissions(323, submissions), true)
+}
+
+func TestIsChallengeInSubmissionsWhenNotExists(t *testing.T) {
+	assert.Equal(t, IsChallengeInSubmissions(5, submissions), false)
+	assert.Equal(t, IsChallengeInSubmissions(6, submissions), false)
+	assert.Equal(t, IsChallengeInSubmissions(7, submissions), false)
+	assert.Equal(t, IsChallengeInSubmissions(8, submissions), false)
+	assert.Equal(t, IsChallengeInSubmissions(324, submissions), false)
+}

--- a/routes/challenges.go
+++ b/routes/challenges.go
@@ -1,7 +1,6 @@
 package routes
 
 import (
-	"fmt"
 	"github.com/gin-gonic/gin"
 	"net/http"
 	"the-wedding-game-api/middleware"
@@ -122,9 +121,6 @@ func GetAllChallenges(c *gin.Context) {
 }
 
 func VerifyAnswer(c *gin.Context) {
-	panic("fuck")
-
-	fmt.Println("wtfd")
 	user, err := middleware.GetCurrentUser(c)
 	if err != nil {
 		_ = c.Error(err)

--- a/routes/challenges.go
+++ b/routes/challenges.go
@@ -1,13 +1,13 @@
 package routes
 
 import (
+	"fmt"
 	"github.com/gin-gonic/gin"
 	"net/http"
 	"the-wedding-game-api/middleware"
 	"the-wedding-game-api/middleware/validators"
 	"the-wedding-game-api/models"
 	"the-wedding-game-api/types"
-	"the-wedding-game-api/utils"
 )
 
 func GetChallengeById(c *gin.Context) {
@@ -103,7 +103,7 @@ func GetAllChallenges(c *gin.Context) {
 	var response types.GetChallengesResponse
 	response.Challenges = make([]types.GetChallengeResponse, 0)
 	for _, challenge := range challengesArr {
-		isCompleted := utils.IsChallengeInSubmissions(challenge.ID, submissions)
+		isCompleted := models.IsChallengeInSubmissions(challenge.ID, submissions)
 
 		response.Challenges = append(response.Challenges, types.GetChallengeResponse{
 			Id:          challenge.ID,
@@ -122,6 +122,9 @@ func GetAllChallenges(c *gin.Context) {
 }
 
 func VerifyAnswer(c *gin.Context) {
+	panic("fuck")
+
+	fmt.Println("wtfd")
 	user, err := middleware.GetCurrentUser(c)
 	if err != nil {
 		_ = c.Error(err)

--- a/routes/router.go
+++ b/routes/router.go
@@ -13,7 +13,7 @@ func GetRouter() *gin.Engine {
 	router.GET("/challenges/:id", GetChallengeById)
 	router.POST("/challenges", CreateChallenge)
 	router.GET("/challenges", GetAllChallenges)
-	//router.POST("/challenges/:id/vffferify", VerifyAnswer)
+	router.POST("/challenges/:id/verify", VerifyAnswer)
 
 	router.POST("/auth/login", Login)
 	router.GET("/auth/current-user", GetCurrentUser)

--- a/routes/router.go
+++ b/routes/router.go
@@ -13,7 +13,7 @@ func GetRouter() *gin.Engine {
 	router.GET("/challenges/:id", GetChallengeById)
 	router.POST("/challenges", CreateChallenge)
 	router.GET("/challenges", GetAllChallenges)
-	router.POST("/challenges/:id/verify", VerifyAnswer)
+	//router.POST("/challenges/:id/vffferify", VerifyAnswer)
 
 	router.POST("/auth/login", Login)
 	router.GET("/auth/current-user", GetCurrentUser)

--- a/routes/upload.go
+++ b/routes/upload.go
@@ -10,7 +10,7 @@ import (
 )
 
 func HandleImageUpload(c *gin.Context) {
-	err := middleware.CheckIsAdmin(c)
+	_, err := middleware.GetCurrentUser(c)
 	if err != nil {
 		_ = c.Error(err)
 		return

--- a/utils/file_utils_test.go
+++ b/utils/file_utils_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"log"
 	"mime/multipart"
 	"net/http/httptest"
 	"os"
@@ -19,7 +20,7 @@ func getFileHeader(filepath string) (*multipart.FileHeader, error) {
 	defer func(file *os.File) {
 		err := file.Close()
 		if err != nil {
-			fmt.Println(fmt.Errorf("error while closing file: %w", err))
+			log.Println(fmt.Errorf("error while closing file: %w", err))
 		}
 	}(file)
 
@@ -59,8 +60,6 @@ func TestGenerateRandomFileName1(t *testing.T) {
 		return
 	}
 
-	fmt.Println(generatedFileName)
-
 	if !test.IsUUID(generatedFileName[:36]) {
 		t.Errorf("Incorrect UUID")
 		return
@@ -78,8 +77,6 @@ func TestGenerateRandomFileName2(t *testing.T) {
 		t.Errorf("Error while generating random file name")
 		return
 	}
-
-	fmt.Println(generatedFileName)
 
 	if !test.IsUUID(generatedFileName[:36]) {
 		t.Errorf("Incorrect UUID")
@@ -99,8 +96,6 @@ func TestGenerateRandomFileName3(t *testing.T) {
 		return
 	}
 
-	fmt.Println(generatedFileName)
-
 	if !test.IsUUID(generatedFileName[:36]) {
 		t.Errorf("Incorrect UUID")
 		return
@@ -118,8 +113,6 @@ func TestGenerateRandomFileName4(t *testing.T) {
 		t.Errorf("Error while generating random file name")
 		return
 	}
-
-	fmt.Println(generatedFileName)
 
 	if !test.IsUUID(generatedFileName[:36]) {
 		t.Errorf("Incorrect UUID")
@@ -139,8 +132,6 @@ func TestGenerateRandomFileName5(t *testing.T) {
 		return
 	}
 
-	fmt.Println(generatedFileName)
-
 	if !test.IsUUID(generatedFileName[:36]) {
 		t.Errorf("Incorrect UUID")
 		return
@@ -158,8 +149,6 @@ func TestGenerateRandomFileNameWithNoExtension1(t *testing.T) {
 		t.Errorf("Error while generating random file name")
 		return
 	}
-
-	fmt.Println(generatedFileName)
 
 	if !test.IsUUID(generatedFileName[:36]) {
 		t.Errorf("Incorrect UUID")
@@ -199,7 +188,7 @@ func TestGetReader(t *testing.T) {
 	defer func(file *os.File) {
 		err := file.Close()
 		if err != nil {
-			fmt.Println(fmt.Errorf("error while closing file: %w", err))
+			log.Println(fmt.Errorf("error while closing file: %w", err))
 		}
 	}(file)
 
@@ -220,8 +209,6 @@ func TestGetReader(t *testing.T) {
 		t.Errorf("Error while reading content")
 		return
 	}
-
-	fmt.Println(string(content))
 
 	expected := "Hello, World!"
 	if string(content) != expected {
@@ -244,9 +231,6 @@ func TestUploadFile(t *testing.T) {
 		t.Errorf(fmt.Errorf("error while uploading file: %w", err).Error())
 		return
 	}
-
-	fmt.Println(url)
-	fmt.Println(url[:20])
 
 	if !IsURLStrict(url) {
 		t.Errorf("invalid URL")

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,17 +4,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
-	"the-wedding-game-api/models"
 )
-
-func IsChallengeInSubmissions(challengeId uint, submissions []models.Submission) bool {
-	for _, submission := range submissions {
-		if submission.ChallengeID == challengeId {
-			return true
-		}
-	}
-	return false
-}
 
 func IsURLStrict(s string) bool {
 	u, err := url.ParseRequestURI(s)

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -2,43 +2,8 @@ package utils
 
 import (
 	"github.com/go-playground/assert/v2"
-	"os"
 	"testing"
-	"the-wedding-game-api/models"
 )
-
-var (
-	submissions []models.Submission
-)
-
-func TestMain(m *testing.M) {
-	submission1 := models.NewSubmission(1, 1, "answer1")
-	submission2 := models.NewSubmission(1, 2, "answer2")
-	submission3 := models.NewSubmission(1, 3, "answer3")
-	submission4 := models.NewSubmission(1, 4, "answer4")
-	submission5 := models.NewSubmission(1, 323, "answer4")
-
-	submissions = []models.Submission{submission1, submission2, submission3, submission4, submission5}
-
-	exitCode := m.Run()
-	os.Exit(exitCode)
-}
-
-func TestIsChallengeInSubmissionsWhenExists(t *testing.T) {
-	assert.Equal(t, IsChallengeInSubmissions(1, submissions), true)
-	assert.Equal(t, IsChallengeInSubmissions(2, submissions), true)
-	assert.Equal(t, IsChallengeInSubmissions(3, submissions), true)
-	assert.Equal(t, IsChallengeInSubmissions(4, submissions), true)
-	assert.Equal(t, IsChallengeInSubmissions(323, submissions), true)
-}
-
-func TestIsChallengeInSubmissionsWhenNotExists(t *testing.T) {
-	assert.Equal(t, IsChallengeInSubmissions(5, submissions), false)
-	assert.Equal(t, IsChallengeInSubmissions(6, submissions), false)
-	assert.Equal(t, IsChallengeInSubmissions(7, submissions), false)
-	assert.Equal(t, IsChallengeInSubmissions(8, submissions), false)
-	assert.Equal(t, IsChallengeInSubmissions(324, submissions), false)
-}
 
 func TestIsURLStrictWithValidUrls(t *testing.T) {
 	assert.Equal(t, IsURLStrict("http://www.google.com"), true)


### PR DESCRIPTION
This pull request includes several changes to the integration tests, models, and routes to improve the functionality and correctness of the application. The most important changes include modifications to the challenge verification tests, the addition of a new utility function, and updates to the upload image tests.

### Integration Tests:
* [`integration_tests/challenges_test.go`](diffhunk://#diff-a7c588a6a497dc32f0f48bdee4fe381f0313a3c126df1fcd8a48e47ad2d07147L1514-R1519): Updated the tests to handle different types of challenges, including `UploadPhotoChallenge` and added new tests for invalid URLs. [[1]](diffhunk://#diff-a7c588a6a497dc32f0f48bdee4fe381f0313a3c126df1fcd8a48e47ad2d07147L1514-R1519) [[2]](diffhunk://#diff-a7c588a6a497dc32f0f48bdee4fe381f0313a3c126df1fcd8a48e47ad2d07147L1543-R1608)
* [`integration_tests/upload_test.go`](diffhunk://#diff-0ef45dac0736cf4ad25fe4f9f1fb321bf509014cc7977c06d2b46524a7427181L6): Modified the upload image tests to check for valid URLs and handle different response scenarios. [[1]](diffhunk://#diff-0ef45dac0736cf4ad25fe4f9f1fb321bf509014cc7977c06d2b46524a7427181L6) [[2]](diffhunk://#diff-0ef45dac0736cf4ad25fe4f9f1fb321bf509014cc7977c06d2b46524a7427181L60-R93) [[3]](diffhunk://#diff-0ef45dac0736cf4ad25fe4f9f1fb321bf509014cc7977c06d2b46524a7427181L105-L106) [[4]](diffhunk://#diff-0ef45dac0736cf4ad25fe4f9f1fb321bf509014cc7977c06d2b46524a7427181L166)

### Models:
* [`models/answers.go`](diffhunk://#diff-0ec44b3620f43d713b5a6215c53b5a7bd6ae173f22e7ede01c18a37bde2286deL35-R61): Refactored the `VerifyAnswer` function to handle different challenge types and added helper functions for specific challenge verifications. [[1]](diffhunk://#diff-0ec44b3620f43d713b5a6215c53b5a7bd6ae173f22e7ede01c18a37bde2286deL35-R61) [[2]](diffhunk://#diff-0ec44b3620f43d713b5a6215c53b5a7bd6ae173f22e7ede01c18a37bde2286deR72-R79)
* [`models/model_utils.go`](diffhunk://#diff-1dc009b9a23a5d1f9aa3e0b0baa6ef6bf4480e64c2c964134beed0f46baec147R1-R10): Added a new utility function `IsChallengeInSubmissions` to check if a challenge exists in the submissions.
* [`models/answers_test.go`](diffhunk://#diff-f01729443bc53fbb3f286f885063a390849f5def3510abf328da225a2bb29dc7R9-R78): Updated the tests to include challenges and verify the new functionality. [[1]](diffhunk://#diff-f01729443bc53fbb3f286f885063a390849f5def3510abf328da225a2bb29dc7R9-R78) [[2]](diffhunk://#diff-f01729443bc53fbb3f286f885063a390849f5def3510abf328da225a2bb29dc7L88-R99) [[3]](diffhunk://#diff-f01729443bc53fbb3f286f885063a390849f5def3510abf328da225a2bb29dc7L103-R115) [[4]](diffhunk://#diff-f01729443bc53fbb3f286f885063a390849f5def3510abf328da225a2bb29dc7R128-R130) [[5]](diffhunk://#diff-f01729443bc53fbb3f286f885063a390849f5def3510abf328da225a2bb29dc7L137-R150)

### Routes:
* [`routes/challenges.go`](diffhunk://#diff-9115914db53ecae33ae8a9ce6d6df8d64b161bc106358eddf1ff0563f44c57a9L106-R105): Updated the route to use the new `IsChallengeInSubmissions` function from the models.
* [`routes/upload.go`](diffhunk://#diff-1263826e2a4dda623e7144c817a15b3d0fa6bb6352d62f7bec2bb2411ecff74fL13-R13): Modified the image upload handler to get the current user instead of checking for admin status.

### Setup and Miscellaneous:
* [`integration_tests/setup_test.go`](diffhunk://#diff-f91e091b06048e5781bbea9721315999baccfdf6bd5c5915a6ab61e0bc6c4f2aL31-R31): Enabled `dockerComposeDown` in the `TearDown` function and removed the debug mode from the database migration. [[1]](diffhunk://#diff-f91e091b06048e5781bbea9721315999baccfdf6bd5c5915a6ab61e0bc6c4f2aL31-R31) [[2]](diffhunk://#diff-f91e091b06048e5781bbea9721315999baccfdf6bd5c5915a6ab61e0bc6c4f2aL80-R80)
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L4-R20): Commented out the server startup code for potential future use.
* [`utils/file_utils_test.go`](diffhunk://#diff-6a454636fbfe03d6e2957501350ba6853e550e01af07062520f9f96618e4c5e8R7): Replaced `fmt.Println` with `log.Println` for error logging. [[1]](diffhunk://#diff-6a454636fbfe03d6e2957501350ba6853e550e01af07062520f9f96618e4c5e8R7) [[2]](diffhunk://#diff-6a454636fbfe03d6e2957501350ba6853e550e01af07062520f9f96618e4c5e8L22-R23)