### PR TITLE
Update dockerfile to create a more lightweight image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
-FROM golang:1.23.0-bullseye
+FROM golang:1.23.0-alpine AS builder
 
 WORKDIR /app
+ADD ./src .
 
-COPY ./src .
+RUN CGO_ENABLED=0 go build -o server
 
-RUN go mod download
+FROM scratch
 
-RUN go build -o /godocker
+COPY --from=builder /app/server /app/server
 
-EXPOSE 8080
-
-CMD ["/godocker"]
-
+CMD ["/app/server"]


### PR DESCRIPTION
This pull request includes significant changes to the `Dockerfile` to improve the build process and reduce the final image size. The most important changes include switching to a multi-stage build, modifying the build commands, and updating the final image configuration.

Improvements to the build process:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R12): Switched from using `golang:1.23.0-bullseye` to `golang:1.23.0-alpine` as the base image for the builder stage to reduce the size of the final image.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R12): Added a multi-stage build process by introducing a `builder` stage and using `scratch` as the final image to further minimize the image size.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R12): Changed the build command to `CGO_ENABLED=0 go build -o server` to ensure the binary is statically linked, which is necessary for using the `scratch` base image.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R12): Updated the final image configuration to copy the built binary from the `builder` stage and set the command to run the server.…cess