### PR TITLE
Optimize continuous delivery workflow

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -10,11 +10,6 @@ jobs:
     push-to-registry:
         name: Push Docker image to Docker Hub
         runs-on: ubuntu-latest
-        permissions:
-          packages: write
-          contents: read
-          attestations: write
-          id-token: write
 
         steps:
           - name: Checkout code

--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -20,36 +20,6 @@ jobs:
           - name: Checkout code
             uses: actions/checkout@v4
 
-          - name: Setup Go
-            uses: actions/setup-go@v2
-            with:
-              go-version: 1.23
-
-          - name: Install dependencies
-            run: go mod download
-            working-directory: src
-
-          - name: Build project
-            run: go build -v ./...
-            working-directory: src
-
-          - name: Install Docker Compose
-            run: |
-              sudo curl -L "https://github.com/docker/compose/releases/download/v2.3.3/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-              sudo chmod +x /usr/local/bin/docker-compose
-              docker-compose --version
-            continue-on-error: false
-
-          - name: Run tests
-            run: go test -v ./... -cover -coverprofile=coverage.txt
-            working-directory: src
-
-          - name: Log in to Docker Hub
-            uses: docker/login-action@v3
-            with:
-              username: ${{ secrets.DOCKER_USERNAME }}
-              password: ${{ secrets.DOCKER_PASSWORD }}
-
           - name: Set up Docker Buildx
             uses: docker/setup-buildx-action@v3
 
@@ -61,10 +31,3 @@ jobs:
               file: ./Dockerfile
               push: true
               tags: kaneeldias/the-wedding-game-api:${{ github.sha }}
-
-          - name: Generate artifact attestation
-            uses: actions/attest-build-provenance@v2
-            with:
-              subject-name: index.docker.io/kaneeldias/the-wedding-game-api
-              subject-digest: ${{ steps.push.outputs.digest }}
-              push-to-registry: true

--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -1,4 +1,4 @@
-name: Continuous Integration
+name: Continuous Delivery
 
 on:
   push:

--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -20,6 +20,12 @@ jobs:
           - name: Checkout code
             uses: actions/checkout@v4
 
+          - name: Log in to Docker Hub
+            uses: docker/login-action@v3
+            with:
+              username: ${{ secrets.DOCKER_USERNAME }}
+              password: ${{ secrets.DOCKER_PASSWORD }}
+
           - name: Set up Docker Buildx
             uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
This pull request includes significant changes to the `.github/workflows/continuous-delivery.yaml` file, transitioning from a continuous integration setup to a continuous delivery setup by removing several steps related to building and testing the project.

Changes to the workflow file:

* Renamed the workflow from "Continuous Integration" to "Continuous Delivery".
* Removed permissions settings for the `push-to-registry` job.
* Eliminated steps for setting up Go, installing dependencies, building the project, installing Docker Compose, and running tests.
* Removed the step for generating artifact attestation.