### PR TITLE
Add ECS to CD pipeline

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -32,3 +32,30 @@ jobs:
               file: ./Dockerfile
               push: true
               tags: kaneeldias/the-wedding-game-api:${{ github.sha }}
+
+          - name: Configure AWS Credentials
+            uses: aws-actions/configure-aws-credentials@v4
+            with:
+                aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                aws-region: us-east-1
+
+          - name: Download task definition
+            run: |
+              aws ecs describe-task-definition --task-definition fargate-node-task-defn --query taskDefinition > task-definition.json
+
+          - name: Fill in the new image ID in the AWS ECS task definition
+            id: task-def
+            uses: aws-actions/amazon-ecs-render-task-definition@v1
+            with:
+              task-definition: task-definition.json
+              container-name: nodejs-app-container
+              image: registry.hub.docker.com/kaneeldias/the-wedding-game-api:${{ github.sha }}
+
+          - name: Deploy AWS ECS task definition
+            uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+            with:
+              task-definition: ${{ steps.task-def.outputs.task-definition }}
+              service: the-wedding-game-api-service-3
+              cluster: the-wedding-game
+              wait-for-service-stability: true


### PR DESCRIPTION
This pull request includes significant updates to the continuous delivery workflow to integrate AWS ECS deployment. The most important changes include configuring AWS credentials, downloading the task definition, updating the task definition with a new image ID, and deploying the updated task definition to AWS ECS.

AWS ECS integration:

* [`.github/workflows/continuous-delivery.yaml`](diffhunk://#diff-0c77a79858c9499f09d8fb937ace1b068cc3b4b1040fe34257420603295e28f5R35-R61): Added steps to configure AWS credentials using `aws-actions/configure-aws-credentials@v4`.
* [`.github/workflows/continuous-delivery.yaml`](diffhunk://#diff-0c77a79858c9499f09d8fb937ace1b068cc3b4b1040fe34257420603295e28f5R35-R61): Added a step to download the current AWS ECS task definition using `aws ecs describe-task-definition`.
* [`.github/workflows/continuous-delivery.yaml`](diffhunk://#diff-0c77a79858c9499f09d8fb937ace1b068cc3b4b1040fe34257420603295e28f5R35-R61): Added a step to update the task definition with the new image ID using `aws-actions/amazon-ecs-render-task-definition@v1`.
* [`.github/workflows/continuous-delivery.yaml`](diffhunk://#diff-0c77a79858c9499f09d8fb937ace1b068cc3b4b1040fe34257420603295e28f5R35-R61): Added a step to deploy the updated task definition to AWS ECS using `aws-actions/amazon-ecs-deploy-task-definition@v2`.