### PR TITLE
Add CA certificates to Dockerfile for secure connections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,12 @@ ADD ./src .
 
 RUN CGO_ENABLED=0 go build -o server
 
+RUN apk add -U --no-cache ca-certificates
+
 FROM scratch
 
 COPY --from=builder /app/server /app/server
+
+COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 CMD ["/app/server"]


### PR DESCRIPTION
This pull request includes an important update to the `Dockerfile` to enhance the security and functionality of the Docker image. The changes ensure that the necessary CA certificates are included for secure communications.

### Security and functionality improvements:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R8-R15): Added a step to install CA certificates and copy them from the Alpine image to the final image to ensure secure HTTPS connections.