### PR TITLE
Enable authentication for admins 

### DIFF
--- a/src/integration_tests/auth_test.go
+++ b/src/integration_tests/auth_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"the-wedding-game-api/db"
 	"the-wedding-game-api/models"
@@ -56,10 +57,10 @@ func TestLogin(t *testing.T) {
 	}
 }
 
-func TestLoginWithAdmin(t *testing.T) {
+func TestLoginWithAdminValidPassword(t *testing.T) {
 	db.ResetConnection()
 	user := models.User{
-		Username: "test_admin_for_login",
+		Username: "test_admin_for_login1",
 		Role:     types.Admin,
 	}
 	_, err := user.Save()
@@ -68,16 +69,72 @@ func TestLoginWithAdmin(t *testing.T) {
 		return
 	}
 
+	err = os.Setenv("ADMIN_PASSWORD", "testpassword")
+	if err != nil {
+		t.Errorf("Error setting environment variable: %s", err.Error())
+		return
+	}
 	loginRequest := types.LoginRequest{
-		Username: "test_admin_for_login",
+		Username: "test_admin_for_login1",
 		Password: "testpassword",
 	}
 	statusCode, body := makeRequest("POST", "/auth/login", loginRequest)
 
-	if statusCode != http.StatusForbidden {
-		t.Errorf("Expected status code 403, got %v", statusCode)
+	if statusCode != http.StatusOK {
+		t.Errorf("Expected status code 200, got %v", statusCode)
 	}
-	expectedBody := `{"message":"access denied","status":"error"}`
+
+	var loginResponse types.LoginResponse
+	decoder := json.NewDecoder(bytes.NewReader([]byte(body)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&loginResponse); err != nil {
+		t.Errorf("Error unmarshalling response: %v", err)
+		return
+	}
+
+	if loginResponse.User.Username != "test_admin_for_login1" {
+		t.Errorf("Expected username test_admin_for_login1, got %v", loginResponse.User.Username)
+	}
+	if loginResponse.User.Role != types.Admin {
+		t.Errorf("Expected role ADMIN, got %v", loginResponse.User.Role)
+	}
+	if loginResponse.AccessToken == "" {
+		t.Errorf("Expected access token to not be empty")
+	}
+	if len(loginResponse.AccessToken) != 36 {
+		t.Errorf("Expected access token to be a UUID")
+	}
+
+}
+
+func TestLoginWithAdminInvalidPassword(t *testing.T) {
+	db.ResetConnection()
+	user := models.User{
+		Username: "test_admin_for_login2",
+		Role:     types.Admin,
+	}
+	_, err := user.Save()
+	if err != nil {
+		t.Errorf("Error creating user")
+		return
+	}
+
+	err = os.Setenv("ADMIN_PASSWORD", "testpassword")
+	if err != nil {
+		t.Errorf("Error setting environment variable: %s", err.Error())
+		return
+	}
+
+	loginRequest := types.LoginRequest{
+		Username: "test_admin_for_login2",
+		Password: "invalidpassword",
+	}
+	statusCode, body := makeRequest("POST", "/auth/login", loginRequest)
+
+	if statusCode != http.StatusUnauthorized {
+		t.Errorf("Expected status code 401, got %v", statusCode)
+	}
+	expectedBody := `{"message":"invalid password","status":"error"}`
 	if body != expectedBody {
 		t.Errorf("Expected body %v, got %v", expectedBody, body)
 	}
@@ -257,11 +314,11 @@ func TestGetCurrentUserWithMissingAccessToken(t *testing.T) {
 	resp := httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
 
-	if resp.Code != http.StatusForbidden {
-		t.Errorf("Expected status code 403, got %v", resp.Code)
+	if resp.Code != http.StatusUnauthorized {
+		t.Errorf("Expected status code 401, got %v", resp.Code)
 	}
 
-	expectedBody := `{"message":"access denied","status":"error"}`
+	expectedBody := `{"message":"access token is not provided","status":"error"}`
 	if resp.Body.String() != expectedBody {
 		t.Errorf("Expected body %v, got %v", expectedBody, resp.Body.String())
 	}
@@ -299,11 +356,11 @@ func TestGetCurrentUserWithInvalidAccessToken(t *testing.T) {
 	resp := httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
 
-	if resp.Code != http.StatusForbidden {
-		t.Errorf("Expected status code 403, got %v", resp.Code)
+	if resp.Code != http.StatusUnauthorized {
+		t.Errorf("Expected status code 401, got %v", resp.Code)
 	}
 
-	expectedBody := `{"message":"access denied","status":"error"}`
+	expectedBody := `{"message":"invalid access token format","status":"error"}`
 	if resp.Body.String() != expectedBody {
 		t.Errorf("Expected body %v, got %v", expectedBody, resp.Body.String())
 	}

--- a/src/integration_tests/challenges_test.go
+++ b/src/integration_tests/challenges_test.go
@@ -300,11 +300,11 @@ func TestGetChallengeByWithNoAccessToken(t *testing.T) {
 
 	statusCode, responseBody := makeRequest("GET", "/challenges/"+strconv.Itoa(int(challenge.ID)), nil)
 
-	if statusCode != http.StatusForbidden {
-		t.Errorf("Expected status code 403, got %v", statusCode)
+	if statusCode != http.StatusUnauthorized {
+		t.Errorf("Expected status code 401, got %v", statusCode)
 	}
 
-	if responseBody != "{\"message\":\"access denied\",\"status\":\"error\"}" {
+	if responseBody != "{\"message\":\"access token is not provided\",\"status\":\"error\"}" {
 		t.Errorf("Expected response Unauthorized, got %v", responseBody)
 	}
 }
@@ -614,11 +614,11 @@ func TestCreateChallengeWithMissingAccessToken(t *testing.T) {
 	}
 	statusCode, responseBody := makeRequest("POST", "/challenges", challengeRequest)
 
-	if statusCode != http.StatusForbidden {
-		t.Errorf("Expected status code 403, got %v", statusCode)
+	if statusCode != http.StatusUnauthorized {
+		t.Errorf("Expected status code 401, got %v", statusCode)
 	}
 
-	if responseBody != "{\"message\":\"access denied\",\"status\":\"error\"}" {
+	if responseBody != "{\"message\":\"access token is not provided\",\"status\":\"error\"}" {
 		t.Errorf("Expected response Unauthorized, got %v", responseBody)
 	}
 }
@@ -1315,11 +1315,11 @@ func TestGetAllChallengesWithoutAccessToken(t *testing.T) {
 
 	statusCode, responseBody := makeRequest("GET", "/challenges", nil)
 
-	if statusCode != http.StatusForbidden {
-		t.Errorf("Expected status code 403, got %v", statusCode)
+	if statusCode != http.StatusUnauthorized {
+		t.Errorf("Expected status code 401, got %v", statusCode)
 	}
 
-	if responseBody != "{\"message\":\"access denied\",\"status\":\"error\"}" {
+	if responseBody != "{\"message\":\"access token is not provided\",\"status\":\"error\"}" {
 		t.Errorf("Expected response Unauthorized, got %v", responseBody)
 	}
 }

--- a/src/integration_tests/upload_test.go
+++ b/src/integration_tests/upload_test.go
@@ -96,12 +96,12 @@ func TestUploadImageNotAdmin(t *testing.T) {
 
 func TestUploadImageNoToken(t *testing.T) {
 	statusCode, body := makeRequestWithFile("POST", "/upload", "image", "../_tests/assets/test_upload_image.jpg", "")
-	if statusCode != http.StatusForbidden {
+	if statusCode != http.StatusUnauthorized {
 		t.Errorf("Expected status code 403, got %v", statusCode)
 		return
 	}
 
-	expectedBody := `{"message":"access denied","status":"error"}`
+	expectedBody := `{"message":"access token is not provided","status":"error"}`
 	if body != expectedBody {
 		t.Errorf("Expected body to be %v, got %v", expectedBody, body)
 	}

--- a/src/middleware/error_handler.go
+++ b/src/middleware/error_handler.go
@@ -15,11 +15,19 @@ func ErrorHandler(c *gin.Context) {
 	err := c.Errors.Last()
 
 	if err != nil {
-		if apperrors.IsAccessTokenNotFoundError(err.Err) || apperrors.IsAuthenticationError(err.Err) ||
-			apperrors.IsAuthorizationError(err.Err) {
+		if apperrors.IsAccessTokenNotFoundError(err.Err) || apperrors.IsAuthorizationError(err.Err) {
 			c.JSON(http.StatusForbidden, gin.H{
 				"status":  "error",
 				"message": "access denied",
+			})
+			c.Abort()
+			return
+		}
+
+		if apperrors.IsAuthenticationError(err.Err) {
+			c.JSON(http.StatusUnauthorized, gin.H{
+				"status":  "error",
+				"message": err.Err.Error(),
 			})
 			c.Abort()
 			return

--- a/src/middleware/error_handler_test.go
+++ b/src/middleware/error_handler_test.go
@@ -35,11 +35,11 @@ func TestErrorHandlerWithAuthenticationError(t *testing.T) {
 	_ = request.Error(apperrors.NewAuthenticationError("test_error"))
 	ErrorHandler(request)
 
-	if request.Writer.Status() != http.StatusForbidden {
-		t.Errorf("expected 403 but got %d", request.Writer.Status())
+	if request.Writer.Status() != http.StatusUnauthorized {
+		t.Errorf("expected 401 but got %d", request.Writer.Status())
 	}
 
-	expectedBody := "{\"message\":\"access denied\",\"status\":\"error\"}"
+	expectedBody := "{\"message\":\"test_error\",\"status\":\"error\"}"
 	if blw.GetBody() != expectedBody {
 		t.Errorf("expected %s but got %s", expectedBody, blw.GetBody())
 	}

--- a/src/models/auth.go
+++ b/src/models/auth.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"gorm.io/gorm"
+	"os"
 	"the-wedding-game-api/db"
 	apperrors "the-wedding-game-api/errors"
 	"the-wedding-game-api/types"
@@ -30,6 +31,14 @@ func DoesUserExist(username string) (bool, User, error) {
 		return false, User{}, err
 	}
 	return true, user, nil
+}
+
+func ValidatePassword(password string) error {
+	expectedPassword := os.Getenv("ADMIN_PASSWORD")
+	if password != expectedPassword {
+		return apperrors.NewAuthenticationError("invalid password")
+	}
+	return nil
 }
 
 func (user User) Save() (User, error) {

--- a/src/models/auth_test.go
+++ b/src/models/auth_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"errors"
+	"os"
 	"testing"
 	test "the-wedding-game-api/_tests"
 	"the-wedding-game-api/db"
@@ -137,5 +138,51 @@ func TestUserSaveError(t *testing.T) {
 	}
 	if err.Error() != "test_error" {
 		t.Errorf("expected test_error but got %s", err.Error())
+	}
+}
+
+func TestValidatePassword1(t *testing.T) {
+	err := os.Setenv("ADMIN_PASSWORD", "test_password")
+	if err != nil {
+		t.Errorf("Failed to set environment variable: %s", err.Error())
+	}
+
+	err = ValidatePassword("test_password")
+	if err != nil {
+		t.Errorf("expected nil but got %s", err.Error())
+		return
+	}
+}
+
+func TestValidatePassword2(t *testing.T) {
+	err := os.Setenv("ADMIN_PASSWORD", "another password")
+	if err != nil {
+		t.Errorf("Failed to set environment variable: %s", err.Error())
+	}
+
+	err = ValidatePassword("another password")
+	if err != nil {
+		t.Errorf("expected nil but got %s", err.Error())
+		return
+	}
+}
+
+func TestValidatePasswordError(t *testing.T) {
+	err := os.Setenv("ADMIN_PASSWORD", "test_password")
+	if err != nil {
+		t.Errorf("Failed to set environment variable: %s", err.Error())
+	}
+
+	err = ValidatePassword("wrong_password")
+	if err == nil {
+		t.Errorf("expected error but got nil")
+		return
+	}
+
+	if !apperrors.IsAuthenticationError(err) {
+		t.Errorf("expected true but got false")
+	}
+	if err.Error() != "invalid password" {
+		t.Errorf("expected invalid password but got %s", err.Error())
 	}
 }

--- a/src/routes/auth.go
+++ b/src/routes/auth.go
@@ -3,7 +3,6 @@ package routes
 import (
 	"github.com/gin-gonic/gin"
 	"net/http"
-	apperrors "the-wedding-game-api/errors"
 	"the-wedding-game-api/middleware"
 	"the-wedding-game-api/models"
 	"the-wedding-game-api/types"
@@ -32,8 +31,11 @@ func Login(c *gin.Context) {
 	}
 
 	if user.Role == types.Admin {
-		_ = c.Error(apperrors.NewAuthorizationError())
-		return
+		err := models.ValidatePassword(loginRequest.Password)
+		if err != nil {
+			_ = c.Error(err)
+			return
+		}
 	}
 
 	accessToken, err := models.LinkAccessTokenToUser(user.ID)


### PR DESCRIPTION
Fixes: https://github.com/the-wedding-game/the-wedding-game-api/issues/34

This pull request includes several changes to the authentication and authorization mechanisms in the integration tests and middleware. The changes focus on updating the status codes for unauthorized access and improving the password validation process for admin users.

### Authentication and Authorization Updates:

* Updated the status codes for unauthorized access from `http.StatusForbidden` (403) to `http.StatusUnauthorized` (401) in various tests, including `auth_test.go`, `challenges_test.go`, and `upload_test.go`. [[1]](diffhunk://#diff-8aed07535d089c9799245c29dbbb67d4121bf7a3da274b28729b8c88df4013cdL260-R321) [[2]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL303-R307) [[3]](diffhunk://#diff-1bb6f3cb8a711fa42c58b8d983c5d528dd18d69ca87a5050ad1442998cc6ff2dL99-R104)
* Changed the error messages in the responses to provide more specific information about the missing or invalid access tokens. [[1]](diffhunk://#diff-8aed07535d089c9799245c29dbbb67d4121bf7a3da274b28729b8c88df4013cdL302-R363) [[2]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL617-R621) [[3]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL1318-R1322)

### Middleware Enhancements:

* Modified the `ErrorHandler` middleware to handle authentication errors separately and return a `http.StatusUnauthorized` (401) status code with a specific error message. [[1]](diffhunk://#diff-00f60cb3ed9df70184fdbf25454ff11dfb60c688bfb6b5c2c67a1d151855e8b1L18-R18) [[2]](diffhunk://#diff-00f60cb3ed9df70184fdbf25454ff11dfb60c688bfb6b5c2c67a1d151855e8b1R27-R35)
* Updated the corresponding test to reflect the new handling of authentication errors.

### Password Validation for Admin Users:

* Added a new function `ValidatePassword` in `auth.go` to check the admin password against an environment variable, and integrated this function into the login process for admin users. [[1]](diffhunk://#diff-9e8cb485e0b6d7002033d7233f07f1bc1d4013bbfd77f1554cfb2b0c8b553e2eR36-R43) [[2]](diffhunk://#diff-fbeb74c591bcd62001a35522a1075c7dbf858067f4ec7ee7d2a2f2297fed292eL35-R39)
* Created new tests for the `ValidatePassword` function to ensure it works correctly.