### PR TITLE
Add functionality to retrieve leaderboard data

### DIFF
--- a/src/_tests/db_mock.go
+++ b/src/_tests/db_mock.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"the-wedding-game-api/db"
 	apperrors "the-wedding-game-api/errors"
+	"the-wedding-game-api/types"
 )
 
 type MockDB struct {
@@ -81,6 +82,18 @@ func (m *MockDB) GetPointsForUser(_ uint) (uint, error) {
 	}
 
 	return 100, nil
+}
+
+func (m *MockDB) GetLeaderboard() ([]types.LeaderboardEntry, error) {
+	if m.Error != nil {
+		return nil, apperrors.NewDatabaseError(m.Error.Error())
+	}
+
+	return []types.LeaderboardEntry{
+		{Username: "user1", Points: 100},
+		{Username: "user2", Points: 200},
+		{Username: "user3", Points: 300},
+	}, nil
 }
 
 func (m *MockDB) GetError() error {

--- a/src/db/db.go
+++ b/src/db/db.go
@@ -1,5 +1,7 @@
 package db
 
+import "the-wedding-game-api/types"
+
 var databaseConnection DatabaseInterface
 
 type DatabaseInterface interface {
@@ -9,6 +11,7 @@ type DatabaseInterface interface {
 	Create(value interface{}) DatabaseInterface
 	Find(dest interface{}, where ...interface{}) DatabaseInterface
 	GetPointsForUser(userId uint) (uint, error)
+	GetLeaderboard() ([]types.LeaderboardEntry, error)
 	GetError() error
 }
 

--- a/src/integration_tests/helpers_test.go
+++ b/src/integration_tests/helpers_test.go
@@ -203,3 +203,22 @@ func completeChallenge(challengeID uint, userID uint) error {
 
 	return nil
 }
+
+func resetDatabase() error {
+	dbURI := fmt.Sprintf("host=%s port=%s user=%s dbname=%s sslmode=disable password=%s",
+		os.Getenv("DB_HOST"),
+		os.Getenv("DB_PORT"),
+		os.Getenv("DB_USER"),
+		os.Getenv("DB_NAME"),
+		os.Getenv("DB_PASS"),
+	)
+
+	database, err := gorm.Open(postgres.Open(dbURI))
+	if err != nil {
+		return err
+	}
+
+	database.Exec("TRUNCATE TABLE users, access_tokens, challenges, submissions RESTART IDENTITY CASCADE")
+
+	return nil
+}

--- a/src/integration_tests/points_test.go
+++ b/src/integration_tests/points_test.go
@@ -3,6 +3,7 @@ package integrationtests
 import (
 	"bytes"
 	"encoding/json"
+	"reflect"
 	"testing"
 	"the-wedding-game-api/types"
 )
@@ -98,6 +99,210 @@ func TestGetCurrentUserPointsNoAccessToken(t *testing.T) {
 	}
 
 	expectedBody := "{\"message\":\"access token is not provided\",\"status\":\"error\"}"
+	if body != expectedBody {
+		t.Errorf("Expected body: %v, got: %v", expectedBody, body)
+	}
+}
+
+func TestGetLeaderboard1(t *testing.T) {
+	if err := resetDatabase(); err != nil {
+		t.Errorf("Error resetting database: %v", err)
+		return
+	}
+
+	challenge1, err1 := createChallengeWithPoints(100)
+	challenge2, err2 := createChallengeWithPoints(200)
+	challenge3, err3 := createChallengeWithPoints(300)
+	if err1 != nil || err2 != nil || err3 != nil {
+		t.Errorf("Error creating challenges")
+		return
+	}
+
+	user1, _, err1 := createUserAndGetAccessToken()
+	user2, _, err2 := createUserAndGetAccessToken()
+	user3, accessToken, err3 := createUserAndGetAccessToken()
+	if err1 != nil || err2 != nil || err3 != nil {
+		t.Errorf("Error creating users")
+		return
+	}
+
+	err1 = completeChallenge(challenge1.ID, user1.ID)
+	err2 = completeChallenge(challenge2.ID, user2.ID)
+	err3 = completeChallenge(challenge3.ID, user3.ID)
+	if err1 != nil || err2 != nil || err3 != nil {
+		t.Errorf("Error completing challenges")
+		return
+	}
+
+	statusCode, body := makeRequestWithToken("GET", "/leaderboard", nil, accessToken.Token)
+	if statusCode != 200 {
+		t.Errorf("Invalid status code: %v", statusCode)
+	}
+
+	var response types.GetLeaderboardResponse
+	decoder := json.NewDecoder(bytes.NewReader([]byte(body)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&response); err != nil {
+		t.Errorf("Error unmarshalling response: %v", err)
+		return
+	}
+
+	expectedResponse := types.GetLeaderboardResponse{
+		Leaderboard: []types.LeaderboardEntry{
+			{Username: user3.Username, Points: 300},
+			{Username: user2.Username, Points: 200},
+			{Username: user1.Username, Points: 100},
+		},
+	}
+	if !reflect.DeepEqual(response, expectedResponse) {
+		t.Errorf("Expected response: %v, got: %v", expectedResponse, response)
+	}
+}
+
+func TestGetLeaderboard2(t *testing.T) {
+	if err := resetDatabase(); err != nil {
+		t.Errorf("Error resetting database: %v", err)
+		return
+	}
+
+	challenge1, err1 := createChallengeWithPoints(100)
+	challenge2, err2 := createChallengeWithPoints(200)
+	challenge3, err3 := createChallengeWithPoints(300)
+	if err1 != nil || err2 != nil || err3 != nil {
+		t.Errorf("Error creating challenges")
+		return
+	}
+
+	user1, _, err1 := createUserAndGetAccessToken()
+	user2, _, err2 := createUserAndGetAccessToken()
+	user3, accessToken, err3 := createUserAndGetAccessToken()
+	if err1 != nil || err2 != nil || err3 != nil {
+		t.Errorf("Error creating users")
+		return
+	}
+
+	err1 = completeChallenge(challenge1.ID, user1.ID)
+	err2 = completeChallenge(challenge2.ID, user2.ID)
+	err3 = completeChallenge(challenge3.ID, user3.ID)
+	err4 := completeChallenge(challenge1.ID, user2.ID)
+	err5 := completeChallenge(challenge3.ID, user2.ID)
+	if err1 != nil || err2 != nil || err3 != nil || err4 != nil || err5 != nil {
+		t.Errorf("Error completing challenges")
+		return
+	}
+
+	statusCode, body := makeRequestWithToken("GET", "/leaderboard", nil, accessToken.Token)
+	if statusCode != 200 {
+		t.Errorf("Invalid status code: %v", statusCode)
+	}
+
+	var response types.GetLeaderboardResponse
+	decoder := json.NewDecoder(bytes.NewReader([]byte(body)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&response); err != nil {
+		t.Errorf("Error unmarshalling response: %v", err)
+		return
+	}
+
+	expectedResponse := types.GetLeaderboardResponse{
+		Leaderboard: []types.LeaderboardEntry{
+			{Username: user2.Username, Points: 600},
+			{Username: user3.Username, Points: 300},
+			{Username: user1.Username, Points: 100},
+		},
+	}
+	if !reflect.DeepEqual(response, expectedResponse) {
+		t.Errorf("Expected response: %v, got: %v", expectedResponse, response)
+	}
+}
+
+func TestGetLeaderboardNoChallenges(t *testing.T) {
+	if err := resetDatabase(); err != nil {
+		t.Errorf("Error resetting database: %v", err)
+		return
+	}
+
+	_, accessToken, err := createUserAndGetAccessToken()
+	if err != nil {
+		t.Errorf("Error creating user and getting access token")
+		return
+	}
+
+	statusCode, body := makeRequestWithToken("GET", "/leaderboard", nil, accessToken.Token)
+	if statusCode != 200 {
+		t.Errorf("Invalid status code: %v", statusCode)
+	}
+
+	var response types.GetLeaderboardResponse
+	decoder := json.NewDecoder(bytes.NewReader([]byte(body)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&response); err != nil {
+		t.Errorf("Error unmarshalling response: %v", err)
+		return
+	}
+
+	if len(response.Leaderboard) != 0 {
+		t.Errorf("Expected empty leaderboard, got: %v", response.Leaderboard)
+	}
+}
+
+func TestGetLeaderboardNoSubmissions(t *testing.T) {
+	if err := resetDatabase(); err != nil {
+		t.Errorf("Error resetting database: %v", err)
+		return
+	}
+
+	_, err1 := createChallengeWithPoints(100)
+	_, err2 := createChallengeWithPoints(200)
+	_, err3 := createChallengeWithPoints(300)
+	if err1 != nil || err2 != nil || err3 != nil {
+		t.Errorf("Error creating challenges")
+		return
+	}
+
+	_, accessToken, err := createUserAndGetAccessToken()
+	if err != nil {
+		t.Errorf("Error creating user and getting access token")
+		return
+	}
+
+	statusCode, body := makeRequestWithToken("GET", "/leaderboard", nil, accessToken.Token)
+	if statusCode != 200 {
+		t.Errorf("Invalid status code: %v", statusCode)
+	}
+
+	var response types.GetLeaderboardResponse
+	decoder := json.NewDecoder(bytes.NewReader([]byte(body)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&response); err != nil {
+		t.Errorf("Error unmarshalling response: %v", err)
+		return
+	}
+
+	if len(response.Leaderboard) != 0 {
+		t.Errorf("Expected empty leaderboard, got: %v", response.Leaderboard)
+	}
+}
+
+func TestGetLeaderboardNoAccessToken(t *testing.T) {
+	statusCode, body := makeRequest("GET", "/leaderboard", nil)
+	if statusCode != 401 {
+		t.Errorf("Invalid status code: %v", statusCode)
+	}
+
+	expectedBody := "{\"message\":\"access token is not provided\",\"status\":\"error\"}"
+	if body != expectedBody {
+		t.Errorf("Expected body: %v, got: %v", expectedBody, body)
+	}
+}
+
+func TestGetLeaderboardInvalidAccessToken(t *testing.T) {
+	statusCode, body := makeRequestWithToken("GET", "/leaderboard", nil, "invalid_token")
+	if statusCode != 403 {
+		t.Errorf("Invalid status code: %v", statusCode)
+	}
+
+	expectedBody := "{\"message\":\"access denied\",\"status\":\"error\"}"
 	if body != expectedBody {
 		t.Errorf("Expected body: %v, got: %v", expectedBody, body)
 	}

--- a/src/models/submissions.go
+++ b/src/models/submissions.go
@@ -4,6 +4,7 @@ import (
 	"gorm.io/gorm"
 	"the-wedding-game-api/db"
 	apperrors "the-wedding-game-api/errors"
+	"the-wedding-game-api/types"
 )
 
 type Submission struct {
@@ -52,4 +53,13 @@ func GetCompletedChallenges(userId uint) ([]Submission, error) {
 		return nil, err
 	}
 	return submissions, nil
+}
+
+func GetLeaderboard() ([]types.LeaderboardEntry, error) {
+	conn := db.GetConnection()
+	leaderboard, err := conn.GetLeaderboard()
+	if err != nil {
+		return nil, err
+	}
+	return leaderboard, nil
 }

--- a/src/models/submissions_test.go
+++ b/src/models/submissions_test.go
@@ -2,10 +2,12 @@ package models
 
 import (
 	"errors"
+	"reflect"
 	"testing"
 	test "the-wedding-game-api/_tests"
 	"the-wedding-game-api/db"
 	apperrors "the-wedding-game-api/errors"
+	"the-wedding-game-api/types"
 )
 
 var (
@@ -217,5 +219,43 @@ func TestGetCompletedChallengesNotFound(t *testing.T) {
 
 	if len(submissions) != 0 {
 		t.Errorf("expected 0 but got %d", len(submissions))
+	}
+}
+
+func TestGetLeaderboard(t *testing.T) {
+	test.SetupMockDb()
+
+	leaderboard, err := GetLeaderboard()
+	if err != nil {
+		t.Errorf("expected nil but got %v", err)
+		return
+	}
+
+	expectedLeaderboard := []types.LeaderboardEntry{
+		{Username: "user1", Points: 100},
+		{Username: "user2", Points: 200},
+		{Username: "user3", Points: 300},
+	}
+
+	if !reflect.DeepEqual(leaderboard, expectedLeaderboard) {
+		t.Errorf("expected %v but got %v", expectedLeaderboard, leaderboard)
+	}
+}
+
+func TestGetLeaderboardError(t *testing.T) {
+	mockDb := test.SetupMockDb()
+	mockDb.Error = errors.New("test_error")
+
+	_, err := GetLeaderboard()
+	if err == nil {
+		t.Errorf("expected error but got nil")
+		return
+	}
+
+	if !apperrors.IsDatabaseError(err) {
+		t.Errorf("expected true but got false")
+	}
+	if err.Error() != "test_error" {
+		t.Errorf("expected test_error but got %s", err.Error())
 	}
 }

--- a/src/routes/points.go
+++ b/src/routes/points.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"net/http"
 	"the-wedding-game-api/middleware"
+	"the-wedding-game-api/models"
 	"the-wedding-game-api/types"
 )
 
@@ -22,6 +23,25 @@ func GetCurrentUserPoints(c *gin.Context) {
 
 	c.IndentedJSON(http.StatusOK, types.CurrentUserPointsResponse{
 		Points: points,
+	})
+	return
+}
+
+func GetLeaderboard(c *gin.Context) {
+	_, err := middleware.GetCurrentUser(c)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	leaderboard, err := models.GetLeaderboard()
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	c.IndentedJSON(http.StatusOK, types.GetLeaderboardResponse{
+		Leaderboard: leaderboard,
 	})
 	return
 }

--- a/src/routes/router.go
+++ b/src/routes/router.go
@@ -25,6 +25,7 @@ func GetRouter() *gin.Engine {
 	router.GET("/auth/current-user", GetCurrentUser)
 
 	router.GET("/points/me", GetCurrentUserPoints)
+	router.GET("/leaderboard", GetLeaderboard)
 
 	router.POST("/upload", HandleImageUpload)
 

--- a/src/types/points.go
+++ b/src/types/points.go
@@ -3,3 +3,12 @@ package types
 type CurrentUserPointsResponse struct {
 	Points uint `json:"points"`
 }
+
+type LeaderboardEntry struct {
+	Username string `json:"username"`
+	Points   uint   `json:"points"`
+}
+
+type GetLeaderboardResponse struct {
+	Leaderboard []LeaderboardEntry `json:"leaderboard"`
+}


### PR DESCRIPTION
Fixes: https://github.com/the-wedding-game/the-wedding-game-api/issues/38

This pull request introduces a new feature to retrieve and display a leaderboard of users based on their points. The changes include updates to the database interface, models, and routes, as well as the addition of new tests to ensure the functionality works as expected.

### New Feature: Leaderboard

* **Database Interface and Implementation:**
  - Added `GetLeaderboard` method to `DatabaseInterface` and implemented it in `gorm_db.go` to query the leaderboard data. [[1]](diffhunk://#diff-cd0acabf7bca1467a781f3eb5f38f7f1953b11c13d934faeaa54ac037f822ad9R14) [[2]](diffhunk://#diff-4b235231213fc66a268a367d19c8291e93534f6de128cc25c03cd10a32358636R71-R88)
  - Enhanced database connection settings in `newDatabase` function.

* **Models:**
  - Added `GetLeaderboard` function in `submissions.go` to retrieve leaderboard data from the database.

* **Routes:**
  - Added `GetLeaderboard` handler in `points.go` and registered the route in `router.go`. [[1]](diffhunk://#diff-b08aea8a611df2cd03d142d54906221d2b7b08104902d24011b7fe1c79a9171fR29-R47) [[2]](diffhunk://#diff-0f2146da3a3dc9bfad9f4b50ed7113dd61e2c1313989cdf2ed06404d564832a4R28)

* **Tests:**
  - Added multiple tests in `points_test.go` to verify the leaderboard functionality under different scenarios.
  - Added tests in `submissions_test.go` to verify the `GetLeaderboard` model function.

* **Types:**
  - Defined new types `LeaderboardEntry` and `GetLeaderboardResponse` in `points.go` for the leaderboard data structure.