### PR TITLE
Add endpoint /gallery to retrieve all submitted images

### DIFF
--- a/src/_tests/db_mock.go
+++ b/src/_tests/db_mock.go
@@ -96,6 +96,18 @@ func (m *MockDB) GetLeaderboard() ([]types.LeaderboardEntry, error) {
 	}, nil
 }
 
+func (m *MockDB) GetGallery() ([]types.GalleryItem, error) {
+	if m.Error != nil {
+		return nil, apperrors.NewDatabaseError(m.Error.Error())
+	}
+
+	return []types.GalleryItem{
+		{Url: "https://example.com/image1.jpg", SubmittedBy: "user1"},
+		{Url: "invalid_url", SubmittedBy: "user2"},
+		{Url: "https://example.com/image3.jpg", SubmittedBy: "user3"},
+	}, nil
+}
+
 func (m *MockDB) GetError() error {
 	if m.Error == nil {
 		return nil

--- a/src/db/db.go
+++ b/src/db/db.go
@@ -1,6 +1,8 @@
 package db
 
-import "the-wedding-game-api/types"
+import (
+	"the-wedding-game-api/types"
+)
 
 var databaseConnection DatabaseInterface
 
@@ -12,6 +14,7 @@ type DatabaseInterface interface {
 	Find(dest interface{}, where ...interface{}) DatabaseInterface
 	GetPointsForUser(userId uint) (uint, error)
 	GetLeaderboard() ([]types.LeaderboardEntry, error)
+	GetGallery() ([]types.GalleryItem, error)
 	GetError() error
 }
 

--- a/src/db/gorm_db.go
+++ b/src/db/gorm_db.go
@@ -86,6 +86,26 @@ func (p *database) GetLeaderboard() ([]types.LeaderboardEntry, error) {
 	return leaderboard, nil
 }
 
+func (p *database) GetGallery() ([]types.GalleryItem, error) {
+	var gallery []types.GalleryItem
+	tx := p.db.Raw(`
+		SELECT 
+		    submissions.answer AS Url,
+		    users.username AS "SubmittedBy"
+		FROM submissions
+		INNER JOIN users ON submissions.user_id = users.id
+		INNER JOIN challenges ON submissions.challenge_id = challenges.id
+		WHERE challenges.type = ?
+		ORDER BY submissions.created_at DESC
+	`, types.UploadPhotoChallenge).Scan(&gallery)
+
+	if tx.Error != nil {
+		return nil, apperrors.NewDatabaseError(tx.Error.Error())
+	}
+
+	return gallery, nil
+}
+
 func (p *database) GetError() error {
 	err := p.db.Error
 	if err == nil {

--- a/src/integration_tests/gallery_test.go
+++ b/src/integration_tests/gallery_test.go
@@ -1,0 +1,313 @@
+package integrationtests
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"the-wedding-game-api/types"
+)
+
+func TestGetGallery1(t *testing.T) {
+	if err := resetDatabase(); err != nil {
+		t.Errorf("Error resetting database: %v", err)
+		return
+	}
+
+	challenge1, err1 := createChallenge()
+	challenge2, err2 := createChallenge()
+	challenge3, err3 := createChallenge()
+	if err1 != nil || err2 != nil || err3 != nil {
+		t.Errorf("Error creating challenges")
+		return
+	}
+
+	user1, _, err1 := createUserAndGetAccessToken()
+	user2, _, err2 := createUserAndGetAccessToken()
+	user3, accessToken, err3 := createUserAndGetAccessToken()
+	if err1 != nil || err2 != nil || err3 != nil {
+		t.Errorf("Error creating users")
+		return
+	}
+
+	err1 = createSubmission(challenge1.ID, user1.ID, "https://example.com/image1.jpg")
+	err2 = createSubmission(challenge2.ID, user2.ID, "https://example.com/image2.jpg")
+	err3 = createSubmission(challenge3.ID, user3.ID, "https://example.com/image3.jpg")
+	if err1 != nil || err2 != nil || err3 != nil {
+		t.Errorf("Error creating submissions")
+		return
+	}
+
+	statusCode, body := makeRequestWithToken("GET", "/gallery", nil, accessToken.Token)
+	if statusCode != 200 {
+		t.Errorf("Invalid status code: %v", statusCode)
+	}
+
+	var response types.GalleryResponse
+	decoder := json.NewDecoder(bytes.NewReader([]byte(body)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&response); err != nil {
+		t.Errorf("Error unmarshalling response: %v", err)
+		return
+	}
+
+	expectedResponse := types.GalleryResponse{
+		Images: []types.GalleryItem{
+			{Url: "https://example.com/image3.jpg", SubmittedBy: user3.Username},
+			{Url: "https://example.com/image2.jpg", SubmittedBy: user2.Username},
+			{Url: "https://example.com/image1.jpg", SubmittedBy: user1.Username},
+		},
+	}
+	if !reflect.DeepEqual(response, expectedResponse) {
+		t.Errorf("Expected response: %v, got: %v", expectedResponse, response)
+	}
+}
+
+func TestGetGallery2(t *testing.T) {
+	if err := resetDatabase(); err != nil {
+		t.Errorf("Error resetting database: %v", err)
+		return
+	}
+
+	challenge1, err1 := createChallenge()
+	challenge2, err2 := createChallenge()
+	challenge3, err3 := createChallenge()
+	if err1 != nil || err2 != nil || err3 != nil {
+		t.Errorf("Error creating challenges")
+		return
+	}
+
+	user1, _, err1 := createUserAndGetAccessToken()
+	user2, _, err2 := createUserAndGetAccessToken()
+	user3, accessToken, err3 := createUserAndGetAccessToken()
+	if err1 != nil || err2 != nil || err3 != nil {
+		t.Errorf("Error creating users")
+		return
+	}
+
+	_ = createSubmission(challenge1.ID, user1.ID, "https://example.com/image1.jpg")
+	_ = createSubmission(challenge1.ID, user2.ID, "https://example.com/image2.jpg")
+	_ = createSubmission(challenge1.ID, user3.ID, "https://example.com/image3.jpg")
+	_ = createSubmission(challenge2.ID, user1.ID, "https://example.com/image4.jpg")
+	_ = createSubmission(challenge2.ID, user2.ID, "https://example.com/image5.jpg")
+	_ = createSubmission(challenge2.ID, user3.ID, "https://example.com/image6.jpg")
+	_ = createSubmission(challenge3.ID, user1.ID, "https://example.com/image7.jpg")
+	_ = createSubmission(challenge3.ID, user2.ID, "https://example.com/image8.jpg")
+	_ = createSubmission(challenge3.ID, user3.ID, "https://example.com/image9.jpg")
+
+	statusCode, body := makeRequestWithToken("GET", "/gallery", nil, accessToken.Token)
+	if statusCode != 200 {
+		t.Errorf("Invalid status code: %v", statusCode)
+	}
+
+	var response types.GalleryResponse
+	decoder := json.NewDecoder(bytes.NewReader([]byte(body)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&response); err != nil {
+		t.Errorf("Error unmarshalling response: %v", err)
+		return
+	}
+
+	expectedResponse := types.GalleryResponse{
+		Images: []types.GalleryItem{
+			{Url: "https://example.com/image9.jpg", SubmittedBy: user3.Username},
+			{Url: "https://example.com/image8.jpg", SubmittedBy: user2.Username},
+			{Url: "https://example.com/image7.jpg", SubmittedBy: user1.Username},
+			{Url: "https://example.com/image6.jpg", SubmittedBy: user3.Username},
+			{Url: "https://example.com/image5.jpg", SubmittedBy: user2.Username},
+			{Url: "https://example.com/image4.jpg", SubmittedBy: user1.Username},
+			{Url: "https://example.com/image3.jpg", SubmittedBy: user3.Username},
+			{Url: "https://example.com/image2.jpg", SubmittedBy: user2.Username},
+			{Url: "https://example.com/image1.jpg", SubmittedBy: user1.Username},
+		},
+	}
+	if !reflect.DeepEqual(response, expectedResponse) {
+		t.Errorf("Expected response: %v, got: %v", expectedResponse, response)
+	}
+}
+
+func TestGalleryWithInvalidUrls(t *testing.T) {
+	if err := resetDatabase(); err != nil {
+		t.Errorf("Error resetting database: %v", err)
+		return
+	}
+
+	challenge1, err1 := createChallenge()
+	challenge2, err2 := createChallenge()
+	challenge3, err3 := createChallenge()
+	if err1 != nil || err2 != nil || err3 != nil {
+		t.Errorf("Error creating challenges")
+		return
+	}
+
+	user1, _, err1 := createUserAndGetAccessToken()
+	user2, _, err2 := createUserAndGetAccessToken()
+	user3, accessToken, err3 := createUserAndGetAccessToken()
+	if err1 != nil || err2 != nil || err3 != nil {
+		t.Errorf("Error creating users")
+		return
+	}
+
+	_ = createSubmission(challenge1.ID, user1.ID, "https://example.com/image1.jpg")
+	_ = createSubmission(challenge1.ID, user2.ID, "https://example.com/image2.jpg")
+	_ = createSubmission(challenge1.ID, user3.ID, "https://example.com/image3.jpg")
+	_ = createSubmission(challenge2.ID, user1.ID, "invalid_url")
+	_ = createSubmission(challenge2.ID, user2.ID, "https://example.com/image5.jpg")
+	_ = createSubmission(challenge2.ID, user3.ID, "https://example.com/image6.jpg")
+	_ = createSubmission(challenge3.ID, user1.ID, "https://example.com/image7.jpg")
+	_ = createSubmission(challenge3.ID, user2.ID, "https://example.com/image8.jpg")
+	_ = createSubmission(challenge3.ID, user3.ID, "invalid_url")
+
+	statusCode, body := makeRequestWithToken("GET", "/gallery", nil, accessToken.Token)
+	if statusCode != 200 {
+		t.Errorf("Invalid status code: %v", statusCode)
+	}
+
+	var response types.GalleryResponse
+	decoder := json.NewDecoder(bytes.NewReader([]byte(body)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&response); err != nil {
+		t.Errorf("Error unmarshalling response: %v", err)
+		return
+	}
+
+	expectedResponse := types.GalleryResponse{
+		Images: []types.GalleryItem{
+			{Url: "https://example.com/image8.jpg", SubmittedBy: user2.Username},
+			{Url: "https://example.com/image7.jpg", SubmittedBy: user1.Username},
+			{Url: "https://example.com/image6.jpg", SubmittedBy: user3.Username},
+			{Url: "https://example.com/image5.jpg", SubmittedBy: user2.Username},
+			{Url: "https://example.com/image3.jpg", SubmittedBy: user3.Username},
+			{Url: "https://example.com/image2.jpg", SubmittedBy: user2.Username},
+			{Url: "https://example.com/image1.jpg", SubmittedBy: user1.Username},
+		},
+	}
+
+	if !reflect.DeepEqual(response, expectedResponse) {
+		t.Errorf("Expected response: %v, got: %v", expectedResponse, response)
+	}
+}
+
+func TestGalleryWithAnswerQuestionChallenges(t *testing.T) {
+	if err := resetDatabase(); err != nil {
+		t.Errorf("Error resetting database: %v", err)
+		return
+	}
+
+	challenge1, err1 := createChallenge()
+	challenge2, err2 := createAnswerQuestionChallenge()
+	challenge3, err3 := createChallenge()
+	if err1 != nil || err2 != nil || err3 != nil {
+		t.Errorf("Error creating challenges")
+		return
+	}
+
+	user1, _, err1 := createUserAndGetAccessToken()
+	user2, _, err2 := createUserAndGetAccessToken()
+	user3, accessToken, err3 := createUserAndGetAccessToken()
+	if err1 != nil || err2 != nil || err3 != nil {
+		t.Errorf("Error creating users")
+		return
+	}
+
+	_ = createSubmission(challenge1.ID, user1.ID, "https://example.com/image1.jpg")
+	_ = createSubmission(challenge1.ID, user2.ID, "https://example.com/image2.jpg")
+	_ = createSubmission(challenge1.ID, user3.ID, "https://example.com/image3.jpg")
+	_ = createSubmission(challenge2.ID, user1.ID, "https://example.com/image4.jpg")
+	_ = createSubmission(challenge2.ID, user2.ID, "https://example.com/image5.jpg")
+	_ = createSubmission(challenge2.ID, user3.ID, "https://example.com/image6.jpg")
+	_ = createSubmission(challenge3.ID, user1.ID, "https://example.com/image7.jpg")
+	_ = createSubmission(challenge3.ID, user2.ID, "https://example.com/image8.jpg")
+	_ = createSubmission(challenge3.ID, user3.ID, "https://example.com/image9.jpg")
+
+	statusCode, body := makeRequestWithToken("GET", "/gallery", nil, accessToken.Token)
+	if statusCode != 200 {
+		t.Errorf("Invalid status code: %v", statusCode)
+	}
+
+	var response types.GalleryResponse
+	decoder := json.NewDecoder(bytes.NewReader([]byte(body)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&response); err != nil {
+		t.Errorf("Error unmarshalling response: %v", err)
+		return
+	}
+
+	expectedResponse := types.GalleryResponse{
+		Images: []types.GalleryItem{
+			{Url: "https://example.com/image9.jpg", SubmittedBy: user3.Username},
+			{Url: "https://example.com/image8.jpg", SubmittedBy: user2.Username},
+			{Url: "https://example.com/image7.jpg", SubmittedBy: user1.Username},
+			{Url: "https://example.com/image3.jpg", SubmittedBy: user3.Username},
+			{Url: "https://example.com/image2.jpg", SubmittedBy: user2.Username},
+			{Url: "https://example.com/image1.jpg", SubmittedBy: user1.Username},
+		},
+	}
+
+	if !reflect.DeepEqual(response, expectedResponse) {
+		t.Errorf("Expected response: %v, got: %v", expectedResponse, response)
+	}
+}
+
+func TestGalleryWithNoSubmissions(t *testing.T) {
+	if err := resetDatabase(); err != nil {
+		t.Errorf("Error resetting database: %v", err)
+		return
+	}
+
+	_, err1 := createChallenge()
+	_, err2 := createChallenge()
+	_, err3 := createChallenge()
+	if err1 != nil || err2 != nil || err3 != nil {
+		t.Errorf("Error creating challenges")
+		return
+	}
+
+	_, accessToken, err := createUserAndGetAccessToken()
+	if err != nil {
+		t.Errorf("Error creating user and getting access token")
+		return
+	}
+
+	statusCode, body := makeRequestWithToken("GET", "/gallery", nil, accessToken.Token)
+	if statusCode != 200 {
+		t.Errorf("Invalid status code: %v", statusCode)
+		return
+	}
+
+	var response types.GalleryResponse
+	decoder := json.NewDecoder(bytes.NewReader([]byte(body)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&response); err != nil {
+		t.Errorf("Error unmarshalling response: %v", err)
+		return
+	}
+
+	if len(response.Images) != 0 {
+		t.Errorf("Expected empty leaderboard, got: %v", response.Images)
+	}
+}
+
+func TestGalleryWithNoAccessToken(t *testing.T) {
+	statusCode, body := makeRequest("GET", "/gallery", nil)
+	if statusCode != 401 {
+		t.Errorf("Invalid status code: %v", statusCode)
+	}
+
+	expectedBody := "{\"message\":\"access token is not provided\",\"status\":\"error\"}"
+	if body != expectedBody {
+		t.Errorf("Expected body: %v, got: %v", expectedBody, body)
+	}
+}
+
+func TestGalleryInvalidAccessToken(t *testing.T) {
+	statusCode, body := makeRequestWithToken("GET", "/gallery", nil, "invalid_token")
+	if statusCode != 403 {
+		t.Errorf("Invalid status code: %v", statusCode)
+	}
+
+	expectedBody := "{\"message\":\"access denied\",\"status\":\"error\"}"
+	if body != expectedBody {
+		t.Errorf("Expected body: %v, got: %v", expectedBody, body)
+	}
+}

--- a/src/integration_tests/helpers_test.go
+++ b/src/integration_tests/helpers_test.go
@@ -173,6 +173,42 @@ func makeRequestWithToken(method string, path string, bodyObj interface{}, acces
 	return resp.Code, resp.Body.String()
 }
 
+func createChallenge() (models.Challenge, error) {
+	challenge := models.Challenge{
+		Name:        "test_challenge",
+		Description: "test_description",
+		Points:      100,
+		Image:       "test_image",
+		Type:        types.UploadPhotoChallenge,
+		Status:      types.ActiveChallenge,
+	}
+
+	challenge, err := challenge.Save()
+	if err != nil {
+		return models.Challenge{}, err
+	}
+
+	return challenge, nil
+}
+
+func createAnswerQuestionChallenge() (models.Challenge, error) {
+	challenge := models.Challenge{
+		Name:        "test_challenge",
+		Description: "test_description",
+		Points:      100,
+		Image:       "test_image",
+		Type:        types.AnswerQuestionChallenge,
+		Status:      types.ActiveChallenge,
+	}
+
+	challenge, err := challenge.Save()
+	if err != nil {
+		return models.Challenge{}, err
+	}
+
+	return challenge, nil
+}
+
 func createChallengeWithPoints(points uint) (models.Challenge, error) {
 	challenge := models.Challenge{
 		Name:        "test_challenge",
@@ -195,6 +231,20 @@ func completeChallenge(challengeID uint, userID uint) error {
 	submission := models.Submission{
 		ChallengeID: challengeID,
 		UserID:      userID,
+	}
+	_, err := submission.Save()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func createSubmission(challengeID uint, userID uint, answer string) error {
+	submission := models.Submission{
+		ChallengeID: challengeID,
+		UserID:      userID,
+		Answer:      answer,
 	}
 	_, err := submission.Save()
 	if err != nil {

--- a/src/models/gallery.go
+++ b/src/models/gallery.go
@@ -1,0 +1,24 @@
+package models
+
+import (
+	"the-wedding-game-api/db"
+	"the-wedding-game-api/types"
+	"the-wedding-game-api/utils"
+)
+
+func GetGalleryImages() ([]types.GalleryItem, error) {
+	conn := db.GetConnection()
+	gallery, err := conn.GetGallery()
+	if err != nil {
+		return nil, err
+	}
+
+	var validGallery []types.GalleryItem
+	for i := range gallery {
+		if utils.IsURLStrict(gallery[i].Url) {
+			validGallery = append(validGallery, gallery[i])
+		}
+	}
+
+	return validGallery, nil
+}

--- a/src/models/gallery_test.go
+++ b/src/models/gallery_test.go
@@ -1,0 +1,61 @@
+package models
+
+import (
+	"errors"
+	"testing"
+	test "the-wedding-game-api/_tests"
+	apperrors "the-wedding-game-api/errors"
+	"the-wedding-game-api/types"
+)
+
+var (
+	testGalleryItem1 = types.GalleryItem{Url: "https://example.com/image1.jpg", SubmittedBy: "user1"}
+	testGalleryItem2 = types.GalleryItem{Url: "https://example.com/image3.jpg", SubmittedBy: "user3"}
+)
+
+func TestGetGalleryImages(t *testing.T) {
+	test.SetupMockDb()
+
+	gallery, err := GetGalleryImages()
+	if err != nil {
+		t.Errorf("expected nil but got %v", err)
+	}
+
+	if len(gallery) != 2 {
+		t.Errorf("expected %d but got %d", 2, len(gallery))
+	}
+
+	if gallery[0].Url != testGalleryItem1.Url {
+		t.Errorf("expected %s but got %s", testGalleryItem1.Url, gallery[0].Url)
+	}
+
+	if gallery[0].SubmittedBy != testGalleryItem1.SubmittedBy {
+		t.Errorf("expected %s but got %s", testGalleryItem1.SubmittedBy, gallery[0].SubmittedBy)
+	}
+
+	if gallery[1].Url != testGalleryItem2.Url {
+		t.Errorf("expected %s but got %s", testGalleryItem2.Url, gallery[1].Url)
+	}
+
+	if gallery[1].SubmittedBy != testGalleryItem2.SubmittedBy {
+		t.Errorf("expected %s but got %s", testGalleryItem2.SubmittedBy, gallery[1].SubmittedBy)
+	}
+}
+
+func TestGetGalleryImagesError(t *testing.T) {
+	mockDb := test.SetupMockDb()
+	mockDb.Error = errors.New("test_error")
+
+	_, err := GetGalleryImages()
+	if err == nil {
+		t.Errorf("expected error but got nil")
+		return
+	}
+
+	if !apperrors.IsDatabaseError(err) {
+		t.Errorf("expected true but got false")
+	}
+	if err.Error() != "test_error" {
+		t.Errorf("expected test_error but got %s", err.Error())
+	}
+}

--- a/src/routes/gallery.go
+++ b/src/routes/gallery.go
@@ -1,0 +1,29 @@
+package routes
+
+import (
+	"github.com/gin-gonic/gin"
+	"net/http"
+	"the-wedding-game-api/middleware"
+	"the-wedding-game-api/models"
+	"the-wedding-game-api/types"
+)
+
+func GetGallery(c *gin.Context) {
+	_, err := middleware.GetCurrentUser(c)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	images, err := models.GetGalleryImages()
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	var response types.GalleryResponse
+	response.Images = images
+
+	c.IndentedJSON(http.StatusOK, response)
+	return
+}

--- a/src/routes/router.go
+++ b/src/routes/router.go
@@ -27,6 +27,8 @@ func GetRouter() *gin.Engine {
 	router.GET("/points/me", GetCurrentUserPoints)
 	router.GET("/leaderboard", GetLeaderboard)
 
+	router.GET("/gallery", GetGallery)
+
 	router.POST("/upload", HandleImageUpload)
 
 	return router

--- a/src/types/gallery.go
+++ b/src/types/gallery.go
@@ -1,0 +1,9 @@
+package types
+
+type GalleryItem struct {
+	Url         string `json:"url"`
+	SubmittedBy string `json:"submitted_by"`
+}
+type GalleryResponse struct {
+	Images []GalleryItem `json:"images"`
+}


### PR DESCRIPTION
Fixes: https://github.com/the-wedding-game/the-wedding-game-api/issues/40

This pull request introduces a new feature to fetch and display a gallery of images submitted by users. The main changes include adding the necessary methods to handle gallery data in the database, creating API endpoints, and implementing integration tests to ensure the feature works correctly.

### New Feature: Gallery

* Added `GetGallery` method to `DatabaseInterface` and its implementations to retrieve gallery items from the database. [[1]](diffhunk://#diff-cd0acabf7bca1467a781f3eb5f38f7f1953b11c13d934faeaa54ac037f822ad9R17) [[2]](diffhunk://#diff-4b235231213fc66a268a367d19c8291e93534f6de128cc25c03cd10a32358636R89-R108)
* Created new `GetGallery` function in `routes/gallery.go` to handle the `/gallery` endpoint and return gallery images. [[1]](diffhunk://#diff-d10216023ed84e61ce23b50606fbc0b79a5f9f31b2e8326a2081d45ecb0bb0faR1-R29) [[2]](diffhunk://#diff-0f2146da3a3dc9bfad9f4b50ed7113dd61e2c1313989cdf2ed06404d564832a4R30-R31)
* Implemented `GetGalleryImages` function in `models/gallery.go` to filter and return valid gallery items.

### Integration Tests

* Added multiple integration tests in `src/integration_tests/gallery_test.go` to verify the `/gallery` endpoint functionality, including scenarios with valid and invalid URLs, no submissions, and invalid access tokens.
* Created helper functions in `src/integration_tests/helpers_test.go` to support the new tests, such as `createChallenge`, `createAnswerQuestionChallenge`, and `createSubmission`. [[1]](diffhunk://#diff-50c447319b82f9f11db82e53f1d77cbe95ea8a3255eca8ee7a65f6c9c8bbaea3R176-R211) [[2]](diffhunk://#diff-50c447319b82f9f11db82e53f1d77cbe95ea8a3255eca8ee7a65f6c9c8bbaea3R243-R256)

### Mock Database

* Updated `src/_tests/db_mock.go` to include a mock implementation of the `GetGallery` method for testing purposes.

### Types and Models

* Defined new types `GalleryItem` and `GalleryResponse` in `src/types/gallery.go` to structure the gallery data.
* Added unit tests for `GetGalleryImages` in `src/models/gallery_test.go` to ensure correct behavior and error handling.