### PR TITLE
Refactor gallery item initialization to use make for validGallery

### DIFF
--- a/src/models/gallery.go
+++ b/src/models/gallery.go
@@ -13,7 +13,7 @@ func GetGalleryImages() ([]types.GalleryItem, error) {
 		return nil, err
 	}
 
-	var validGallery []types.GalleryItem
+	var validGallery = make([]types.GalleryItem, 0)
 	for i := range gallery {
 		if utils.IsURLStrict(gallery[i].Url) {
 			validGallery = append(validGallery, gallery[i])


### PR DESCRIPTION
Fixes: https://github.com/the-wedding-game/the-wedding-game-api/issues/42

This pull request includes a small but significant change to the `GetGalleryImages` function in the `src/models/gallery.go` file. The change improves the initialization of the `validGallery` slice.

* [`src/models/gallery.go`](diffhunk://#diff-f8e5f8e3053b628434ad961a41af37386c6258e2f16aaf688f89295dbb006190L16-R16): Modified the initialization of the `validGallery` slice to use `make` with an initial length of 0, which is more efficient and idiomatic.