### PR TITLE
Refactor to move database login from db package to models package

### DIFF
--- a/src/_tests/test_utils.go
+++ b/src/_tests/test_utils.go
@@ -5,17 +5,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"net/http/httptest"
 	"strings"
-	"the-wedding-game-api/db"
 	"the-wedding-game-api/storage"
 )
-
-func SetupMockDb() *MockDB {
-	mockDB := &MockDB{}
-	db.GetConnection = func() db.DatabaseInterface {
-		return mockDB
-	}
-	return mockDB
-}
 
 func SetupMockStorage() *MockStorage {
 	mockStorage := &MockStorage{}

--- a/src/integration_tests/auth_test.go
+++ b/src/integration_tests/auth_test.go
@@ -7,13 +7,12 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
-	"the-wedding-game-api/db"
 	"the-wedding-game-api/models"
 	"the-wedding-game-api/types"
 )
 
 func TestLogin(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	user := &models.User{
 		Username: "test_user_for_login",
@@ -58,7 +57,7 @@ func TestLogin(t *testing.T) {
 }
 
 func TestLoginWithAdminValidPassword(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 	user := models.User{
 		Username: "test_admin_for_login1",
 		Role:     types.Admin,
@@ -108,7 +107,7 @@ func TestLoginWithAdminValidPassword(t *testing.T) {
 }
 
 func TestLoginWithAdminInvalidPassword(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 	user := models.User{
 		Username: "test_admin_for_login2",
 		Role:     types.Admin,
@@ -182,7 +181,7 @@ func TestLoginWithEmptyUsername(t *testing.T) {
 }
 
 func TestLoginWithEmptyPassword(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	user := &models.User{
 		Username: "test_user_for_login_with_empty_password",
@@ -221,7 +220,7 @@ func TestLoginWithEmptyPassword(t *testing.T) {
 }
 
 func TestLoginWithNonexistentUser(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	loginRequest := types.LoginRequest{
 		Username: "nonexistent_user",
@@ -256,7 +255,7 @@ func TestLoginWithNonexistentUser(t *testing.T) {
 }
 
 func TestGetCurrentUser(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	user := models.User{
 		Username: "test_user_for_get_current_user",

--- a/src/integration_tests/challenges_test.go
+++ b/src/integration_tests/challenges_test.go
@@ -6,13 +6,12 @@ import (
 	"net/http"
 	"strconv"
 	"testing"
-	"the-wedding-game-api/db"
 	"the-wedding-game-api/models"
 	"the-wedding-game-api/types"
 )
 
 func TestGetChallengeByIdUploadPhoto(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	challenge := models.Challenge{
 		Name:        "test_challenge",
@@ -79,7 +78,7 @@ func TestGetChallengeByIdUploadPhoto(t *testing.T) {
 }
 
 func TestGetChallengeByIdAnswerQuestion(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	challenge := models.Challenge{
 		Name:        "test_challenge",
@@ -146,7 +145,7 @@ func TestGetChallengeByIdAnswerQuestion(t *testing.T) {
 }
 
 func TestGetChallengeByIdCompleted(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	challenge := models.Challenge{
 		Name:        "test_challenge",
@@ -220,7 +219,7 @@ func TestGetChallengeByIdCompleted(t *testing.T) {
 }
 
 func TestGetChallengeByWithNoAccessToken(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	challenge := models.Challenge{
 		Name:        "test_challenge",
@@ -248,7 +247,7 @@ func TestGetChallengeByWithNoAccessToken(t *testing.T) {
 }
 
 func TestGetChallengeByIdInvalidAccessToken(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	challenge := models.Challenge{
 		Name:        "test_challenge",
@@ -276,7 +275,7 @@ func TestGetChallengeByIdInvalidAccessToken(t *testing.T) {
 }
 
 func TestGetChallengeByIdNonExistentChallenge(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	_, accessToken, err := createUserAndGetAccessToken()
 	if err != nil {
@@ -296,7 +295,7 @@ func TestGetChallengeByIdNonExistentChallenge(t *testing.T) {
 }
 
 func TestGetChallengeByIdInvalidChallengeId(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	_, accessToken, err := createUserAndGetAccessToken()
 	if err != nil {
@@ -316,7 +315,7 @@ func TestGetChallengeByIdInvalidChallengeId(t *testing.T) {
 }
 
 func TestGetChallengeByIdWithInactiveChallenge(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	challenge := models.Challenge{
 		Name:        "test_challenge",
@@ -382,7 +381,7 @@ func TestGetChallengeByIdWithInactiveChallenge(t *testing.T) {
 }
 
 func TestCreateChallengeUploadPhoto(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	_, accessToken, err := createAdminAndGetAccessToken()
 	if err != nil {
@@ -437,7 +436,7 @@ func TestCreateChallengeUploadPhoto(t *testing.T) {
 }
 
 func TestCreateChallengeAnswerQuestion(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	_, accessToken, err := createAdminAndGetAccessToken()
 	if err != nil {
@@ -493,7 +492,7 @@ func TestCreateChallengeAnswerQuestion(t *testing.T) {
 }
 
 func TestCreateChallengeAsNotAdmin(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	_, accessToken, err := createUserAndGetAccessToken()
 	if err != nil {
@@ -520,7 +519,7 @@ func TestCreateChallengeAsNotAdmin(t *testing.T) {
 }
 
 func TestCreateChallengeWithInvalidAccessToken(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	challengeRequest := types.CreateChallengeRequest{
 		Name:        "test_challenge",
@@ -541,7 +540,7 @@ func TestCreateChallengeWithInvalidAccessToken(t *testing.T) {
 }
 
 func TestCreateChallengeWithMissingAccessToken(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	challengeRequest := types.CreateChallengeRequest{
 		Name:        "test_challenge",
@@ -562,7 +561,7 @@ func TestCreateChallengeWithMissingAccessToken(t *testing.T) {
 }
 
 func TestCreateChallengeWithMissingBody(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	_, accessToken, err := createAdminAndGetAccessToken()
 	if err != nil {
@@ -582,7 +581,7 @@ func TestCreateChallengeWithMissingBody(t *testing.T) {
 }
 
 func TestCreateChallengeWithEmptyBody(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	_, accessToken, err := createAdminAndGetAccessToken()
 	if err != nil {
@@ -602,7 +601,7 @@ func TestCreateChallengeWithEmptyBody(t *testing.T) {
 }
 
 func TestCreateChallengeWithEmptyName(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	_, accessToken, err := createAdminAndGetAccessToken()
 	if err != nil {
@@ -629,7 +628,7 @@ func TestCreateChallengeWithEmptyName(t *testing.T) {
 }
 
 func TestCreateChallengeWithEmptyDescription(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	_, accessToken, err := createAdminAndGetAccessToken()
 	if err != nil {
@@ -656,7 +655,7 @@ func TestCreateChallengeWithEmptyDescription(t *testing.T) {
 }
 
 func TestCreateChallengeWithEmptyPoints(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	_, accessToken, err := createAdminAndGetAccessToken()
 	if err != nil {
@@ -683,7 +682,7 @@ func TestCreateChallengeWithEmptyPoints(t *testing.T) {
 }
 
 func TestCreateChallengeWithZeroPoints(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	_, accessToken, err := createAdminAndGetAccessToken()
 	if err != nil {
@@ -710,7 +709,7 @@ func TestCreateChallengeWithZeroPoints(t *testing.T) {
 }
 
 func TestCreateChallengeWithNegativePoints(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	_, accessToken, err := createAdminAndGetAccessToken()
 	if err != nil {
@@ -737,7 +736,7 @@ func TestCreateChallengeWithNegativePoints(t *testing.T) {
 }
 
 func TestCreateChallengeWithEmptyImage(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	_, accessToken, err := createAdminAndGetAccessToken()
 	if err != nil {
@@ -764,7 +763,7 @@ func TestCreateChallengeWithEmptyImage(t *testing.T) {
 }
 
 func TestCreateChallengeWithInvalidImage(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	_, accessToken, err := createAdminAndGetAccessToken()
 	if err != nil {
@@ -791,7 +790,7 @@ func TestCreateChallengeWithInvalidImage(t *testing.T) {
 }
 
 func TestCreateChallengeWithInvalidType(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	_, accessToken, err := createAdminAndGetAccessToken()
 	if err != nil {
@@ -818,7 +817,7 @@ func TestCreateChallengeWithInvalidType(t *testing.T) {
 }
 
 func TestCreateChallengeWithEmptyType(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	_, accessToken, err := createAdminAndGetAccessToken()
 	if err != nil {
@@ -845,7 +844,7 @@ func TestCreateChallengeWithEmptyType(t *testing.T) {
 }
 
 func TestCreateChallengeWithEmptyAnswerForAnswerQuestionChallenge(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	_, accessToken, err := createAdminAndGetAccessToken()
 	if err != nil {
@@ -873,7 +872,7 @@ func TestCreateChallengeWithEmptyAnswerForAnswerQuestionChallenge(t *testing.T) 
 }
 
 func TestCreateChallengeWithoutAnswerForAnswerQuestionChallenge(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	_, accessToken, err := createAdminAndGetAccessToken()
 	if err != nil {
@@ -900,7 +899,7 @@ func TestCreateChallengeWithoutAnswerForAnswerQuestionChallenge(t *testing.T) {
 }
 
 func TestGetAllChallengesEmpty(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 	deleteAllChallenges()
 
 	_, accessToken, err := createUserAndGetAccessToken()
@@ -929,7 +928,7 @@ func TestGetAllChallengesEmpty(t *testing.T) {
 }
 
 func TestGetAllChallenges(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 	deleteAllChallenges()
 
 	challenge1 := models.Challenge{
@@ -982,6 +981,7 @@ func TestGetAllChallenges(t *testing.T) {
 
 	if len(response.Challenges) != 2 {
 		t.Errorf("Expected 2 challenges, got %v", len(response.Challenges))
+		return
 	}
 
 	if response.Challenges[0].Name != "test_challenge_1" {
@@ -1043,7 +1043,7 @@ func TestGetAllChallenges(t *testing.T) {
 }
 
 func TestGetAllChallengesWithInactiveChallenges(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 	deleteAllChallenges()
 
 	challenge1 := models.Challenge{
@@ -1128,7 +1128,7 @@ func TestGetAllChallengesWithInactiveChallenges(t *testing.T) {
 }
 
 func TestGetAllChallengesWithCompleted(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 	deleteAllChallenges()
 
 	challenge1 := models.Challenge{
@@ -1248,7 +1248,7 @@ func TestGetAllChallengesWithCompleted(t *testing.T) {
 }
 
 func TestGetAllChallengesWithoutAccessToken(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 	deleteAllChallenges()
 
 	statusCode, responseBody := makeRequest("GET", "/challenges", nil)
@@ -1263,7 +1263,7 @@ func TestGetAllChallengesWithoutAccessToken(t *testing.T) {
 }
 
 func TestGetAllChallengesWithInvalidAccessToken(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 	deleteAllChallenges()
 
 	statusCode, responseBody := makeRequestWithToken("GET", "/challenges", nil, "invalid_access_token")
@@ -1278,7 +1278,7 @@ func TestGetAllChallengesWithInvalidAccessToken(t *testing.T) {
 }
 
 func TestVerifyAnswerQuestionChallengeCorrectAnswer(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	_, accessToken, err := createUserAndGetAccessToken()
 	if err != nil {
@@ -1355,7 +1355,7 @@ func TestVerifyAnswerQuestionChallengeCorrectAnswer(t *testing.T) {
 }
 
 func TestVerifyAnswerQuestionChallengeIncorrectAnswer(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	_, accessToken, err := createUserAndGetAccessToken()
 	if err != nil {
@@ -1431,7 +1431,7 @@ func TestVerifyAnswerQuestionChallengeIncorrectAnswer(t *testing.T) {
 }
 
 func TestVerifyAnswerChallengeDoesNotExist(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	_, accessToken, err := createUserAndGetAccessToken()
 	if err != nil {
@@ -1455,7 +1455,7 @@ func TestVerifyAnswerChallengeDoesNotExist(t *testing.T) {
 }
 
 func TestVerifyAnswerChallengeUploadPhotoChallenge(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	_, accessToken, err := createUserAndGetAccessToken()
 	if err != nil {
@@ -1511,7 +1511,7 @@ func TestVerifyAnswerChallengeUploadPhotoChallenge(t *testing.T) {
 }
 
 func TestVerifyAnswerChallengeUploadPhotoChallengeInvalidUrl(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	_, accessToken, err := createUserAndGetAccessToken()
 	if err != nil {
@@ -1549,7 +1549,7 @@ func TestVerifyAnswerChallengeUploadPhotoChallengeInvalidUrl(t *testing.T) {
 }
 
 func TestVerifyAnswerChallengeAlreadyCompleted(t *testing.T) {
-	db.ResetConnection()
+	models.ResetConnection()
 
 	_, accessToken, err := createUserAndGetAccessToken()
 	if err != nil {

--- a/src/integration_tests/helpers_test.go
+++ b/src/integration_tests/helpers_test.go
@@ -71,7 +71,13 @@ func deleteAllChallenges() {
 		log.Fatalf("Error connecting to database: %v", err)
 	}
 
-	database.Delete(&models.Challenge{}, "1 = 1")
+	database.Exec(`DELETE FROM answers`)
+	database.Exec(`DELETE FROM submissions`)
+	database.Exec(`DELETE FROM challenges`)
+
+	if database.Error != nil {
+		log.Fatalf("Error deleting challenges: %v", database.Error)
+	}
 }
 
 func makeRequest(method string, path string, bodyObj interface{}) (int, string) {

--- a/src/middleware/auth_test.go
+++ b/src/middleware/auth_test.go
@@ -3,7 +3,6 @@ package middleware
 import (
 	"testing"
 	test "the-wedding-game-api/_tests"
-	"the-wedding-game-api/db"
 	apperrors "the-wedding-game-api/errors"
 	"the-wedding-game-api/models"
 	"the-wedding-game-api/types"
@@ -15,18 +14,26 @@ var (
 	testUserAdmin   = models.User{Username: "test_username", Role: types.Admin}
 )
 
+func SetupMockDb() *models.MockDB {
+	mockDB := &models.MockDB{}
+	models.GetConnection = func() models.DatabaseInterface {
+		return mockDB
+	}
+	return mockDB
+}
+
 func createTestAccessToken(accessToken models.AccessToken) {
-	database := db.GetConnection()
+	database := models.GetConnection()
 	database.Create(&accessToken)
 }
 
 func createTestUser(user models.User) {
-	database := db.GetConnection()
+	database := models.GetConnection()
 	database.Create(&user)
 }
 
 func TestGetCurrentUser(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 	createTestAccessToken(testAccessToken)
 	createTestUser(testUser)
 
@@ -83,7 +90,7 @@ func TestGetCurrentUserInvalidAccessTokenFormat(t *testing.T) {
 }
 
 func TestCheckIsAdmin(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 	createTestAccessToken(testAccessToken)
 	createTestUser(testUserAdmin)
 
@@ -97,7 +104,7 @@ func TestCheckIsAdmin(t *testing.T) {
 }
 
 func TestCheckIsAdminNotAdmin(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 	createTestAccessToken(testAccessToken)
 	createTestUser(testUser)
 

--- a/src/middleware/error_handler.go
+++ b/src/middleware/error_handler.go
@@ -1,12 +1,11 @@
 package middleware
 
 import (
+	"github.com/gin-gonic/gin"
 	"log"
 	"net/http"
 	"strings"
 	apperrors "the-wedding-game-api/errors"
-
-	"github.com/gin-gonic/gin"
 )
 
 func ErrorHandler(c *gin.Context) {

--- a/src/models/access_tokens.go
+++ b/src/models/access_tokens.go
@@ -4,7 +4,6 @@ import (
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 	"strconv"
-	"the-wedding-game-api/db"
 	apperrors "the-wedding-game-api/errors"
 	"time"
 )
@@ -22,7 +21,7 @@ func generateAccessToken() string {
 }
 
 func LinkAccessTokenToUser(userId uint) (AccessToken, error) {
-	conn := db.GetConnection()
+	conn := GetConnection()
 	token := generateAccessToken()
 	expiresOn := time.Now().Add(24 * time.Hour).Unix()
 	accessToken := AccessToken{Token: token, UserID: userId, ExpiresOn: expiresOn}
@@ -33,7 +32,7 @@ func LinkAccessTokenToUser(userId uint) (AccessToken, error) {
 }
 
 func GetUserByAccessToken(token string) (User, error) {
-	conn := db.GetConnection()
+	conn := GetConnection()
 	var accessToken AccessToken
 	if err := conn.Where("token = ?", token).First(&accessToken).GetError(); err != nil {
 		if apperrors.IsRecordNotFoundError(err) {

--- a/src/models/access_tokens_test.go
+++ b/src/models/access_tokens_test.go
@@ -3,8 +3,6 @@ package models
 import (
 	"errors"
 	"testing"
-	test "the-wedding-game-api/_tests"
-	"the-wedding-game-api/db"
 	apperrors "the-wedding-game-api/errors"
 	"time"
 )
@@ -14,17 +12,17 @@ var (
 )
 
 func createTestAccessToken(accessToken AccessToken) {
-	database := db.GetConnection()
+	database := GetConnection()
 	database.Create(&accessToken)
 }
 
 func createTestUser(user User) {
-	database := db.GetConnection()
+	database := GetConnection()
 	database.Create(&user)
 }
 
 func TestLinkAccessTokenToUser(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 	accessToken, err := LinkAccessTokenToUser(1)
 	if err != nil {
 		t.Errorf("expected nil but got %s", err.Error())
@@ -46,7 +44,7 @@ func TestLinkAccessTokenToUser(t *testing.T) {
 }
 
 func TestLinkAccessTokenToUserNegative(t *testing.T) {
-	mockDb := test.SetupMockDb()
+	mockDb := SetupMockDb()
 
 	mockDb.Error = errors.New("test_error")
 
@@ -65,7 +63,7 @@ func TestLinkAccessTokenToUserNegative(t *testing.T) {
 }
 
 func TestGetUserByAccessToken(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 	createTestAccessToken(testAccessToken)
 	createTestUser(testUser)
 
@@ -81,7 +79,7 @@ func TestGetUserByAccessToken(t *testing.T) {
 }
 
 func TestGetUserByAccessTokenNotFound(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 
 	_, err := GetUserByAccessToken("test_access_token")
 	if err == nil {
@@ -98,7 +96,7 @@ func TestGetUserByAccessTokenNotFound(t *testing.T) {
 }
 
 func TestGetUserByAccessTokenUserNotFound(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 	createTestAccessToken(testAccessToken)
 
 	_, err := GetUserByAccessToken("test_access_token")
@@ -116,7 +114,7 @@ func TestGetUserByAccessTokenUserNotFound(t *testing.T) {
 }
 
 func TestGetUserByAccessTokenError(t *testing.T) {
-	mockDb := test.SetupMockDb()
+	mockDb := SetupMockDb()
 	createTestAccessToken(testAccessToken)
 	createTestUser(testUser)
 

--- a/src/models/answers.go
+++ b/src/models/answers.go
@@ -3,7 +3,6 @@ package models
 import (
 	"gorm.io/gorm"
 	"strconv"
-	"the-wedding-game-api/db"
 	apperrors "the-wedding-game-api/errors"
 	"the-wedding-game-api/types"
 	"the-wedding-game-api/utils"
@@ -25,7 +24,7 @@ func NewAnswer(challengeId uint, value string) Answer {
 }
 
 func (answer Answer) Save() (Answer, error) {
-	conn := db.GetConnection()
+	conn := GetConnection()
 	if err := conn.Create(&answer).GetError(); err != nil {
 		return Answer{}, err
 	}
@@ -33,7 +32,7 @@ func (answer Answer) Save() (Answer, error) {
 }
 
 func VerifyAnswer(challengeId uint, answer string) (bool, error) {
-	conn := db.GetConnection()
+	conn := GetConnection()
 
 	var challengeModel Challenge
 	err := conn.Where("id = ?", challengeId).First(&challengeModel).GetError()
@@ -56,7 +55,7 @@ func VerifyAnswer(challengeId uint, answer string) (bool, error) {
 }
 
 func verifyAnswerForQuestion(challengeId uint, answer string) (bool, error) {
-	conn := db.GetConnection()
+	conn := GetConnection()
 
 	var answerModel Answer
 	err := conn.Where("challenge_id = ?", challengeId).First(&answerModel).GetError()

--- a/src/models/answers_test.go
+++ b/src/models/answers_test.go
@@ -3,8 +3,6 @@ package models
 import (
 	"errors"
 	"testing"
-	test "the-wedding-game-api/_tests"
-	"the-wedding-game-api/db"
 	apperrors "the-wedding-game-api/errors"
 	"the-wedding-game-api/types"
 )
@@ -16,12 +14,12 @@ var (
 )
 
 func createTestAnswer(answer Answer) {
-	database := db.GetConnection()
+	database := GetConnection()
 	database.Create(&answer)
 }
 
 func createTestChallenge(challenge Challenge) {
-	database := db.GetConnection()
+	database := GetConnection()
 	database.Create(&challenge)
 }
 
@@ -44,7 +42,7 @@ func TestNewAnswer(t *testing.T) {
 }
 
 func TestAnswerSave(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 
 	answer := NewAnswer(testAnswer123.ChallengeID, testAnswer123.Value)
 	savedAnswer, err := answer.Save()
@@ -60,7 +58,7 @@ func TestAnswerSave(t *testing.T) {
 		t.Errorf("expected %s but got %s", testAnswer123.Value, savedAnswer.Value)
 	}
 
-	mockDB := db.GetConnection()
+	mockDB := GetConnection()
 	retrievedAnswer := Answer{}
 	mockDB.First(&retrievedAnswer, testAnswer123.ID)
 	if retrievedAnswer.ID != testAnswer123.ID {
@@ -72,7 +70,7 @@ func TestAnswerSave(t *testing.T) {
 }
 
 func TestAnswerSaveNegative(t *testing.T) {
-	mockDB := test.SetupMockDb()
+	mockDB := SetupMockDb()
 	mockDB.Error = errors.New("test_error")
 
 	answer := NewAnswer(testAnswer123.ChallengeID, testAnswer123.Value)
@@ -91,7 +89,7 @@ func TestAnswerSaveNegative(t *testing.T) {
 }
 
 func TestVerifyAnswer(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 
 	createTestChallenge(testChallenge123)
 	createTestAnswer(testAnswer123)
@@ -108,7 +106,7 @@ func TestVerifyAnswer(t *testing.T) {
 }
 
 func TestVerifyAnswerIncorrect(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 	createTestChallenge(testChallenge123)
 	createTestAnswer(testAnswer123)
 
@@ -124,7 +122,7 @@ func TestVerifyAnswerIncorrect(t *testing.T) {
 }
 
 func TestVerifyAnswerNotFound(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 	createTestChallenge(testChallenge123)
 
 	_, err := VerifyAnswer(testAnswer123.ChallengeID, testAnswer123.Value)
@@ -142,7 +140,7 @@ func TestVerifyAnswerNotFound(t *testing.T) {
 }
 
 func TestVerifyAnswerError(t *testing.T) {
-	mockDB := test.SetupMockDb()
+	mockDB := SetupMockDb()
 	mockDB.Error = errors.New("test_error")
 
 	createTestChallenge(testChallenge123)

--- a/src/models/auth.go
+++ b/src/models/auth.go
@@ -3,7 +3,6 @@ package models
 import (
 	"gorm.io/gorm"
 	"os"
-	"the-wedding-game-api/db"
 	apperrors "the-wedding-game-api/errors"
 	"the-wedding-game-api/types"
 )
@@ -23,7 +22,7 @@ func NewUser(username string) User {
 
 func DoesUserExist(username string) (bool, User, error) {
 	var user User
-	conn := db.GetConnection()
+	conn := GetConnection()
 	if err := conn.Where("username = ?", username).First(&user).GetError(); err != nil {
 		if apperrors.IsRecordNotFoundError(err) {
 			return false, User{}, nil
@@ -42,7 +41,7 @@ func ValidatePassword(password string) error {
 }
 
 func (user User) Save() (User, error) {
-	conn := db.GetConnection()
+	conn := GetConnection()
 	if err := conn.Create(&user).GetError(); err != nil {
 		return User{}, err
 	}
@@ -50,7 +49,7 @@ func (user User) Save() (User, error) {
 }
 
 func (user User) GetPoints() (uint, error) {
-	conn := db.GetConnection()
+	conn := GetConnection()
 	points, err := conn.GetPointsForUser(user.ID)
 	if err != nil {
 		return 0, err

--- a/src/models/auth_test.go
+++ b/src/models/auth_test.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"os"
 	"testing"
-	test "the-wedding-game-api/_tests"
-	"the-wedding-game-api/db"
 	apperrors "the-wedding-game-api/errors"
 	"the-wedding-game-api/types"
 )
@@ -34,7 +32,7 @@ func TestNewUser(t *testing.T) {
 }
 
 func TestDoesUserExist(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 	createTestUser(testUser)
 
 	exists, user, err := DoesUserExist(testUser.Username)
@@ -55,7 +53,7 @@ func TestDoesUserExist(t *testing.T) {
 }
 
 func TestDoesUserExistNotFound(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 
 	exists, _, err := DoesUserExist(testUserAdmin.Username)
 	if err != nil {
@@ -69,7 +67,7 @@ func TestDoesUserExistNotFound(t *testing.T) {
 }
 
 func TestDoesUserExistError(t *testing.T) {
-	mockDb := test.SetupMockDb()
+	mockDb := SetupMockDb()
 	createTestUser(testUser)
 
 	mockDb.Error = errors.New("test_error")
@@ -91,7 +89,7 @@ func TestDoesUserExistError(t *testing.T) {
 }
 
 func TestUserSave(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 
 	user := NewUser(testUser.Username)
 	savedUser, err := user.Save()
@@ -107,7 +105,7 @@ func TestUserSave(t *testing.T) {
 		t.Errorf("expected PLAYER but got %s", savedUser.Role)
 	}
 
-	mockDb := db.GetConnection()
+	mockDb := GetConnection()
 	var userFromDb User
 	err = mockDb.First(&userFromDb, savedUser.ID).GetError()
 	if err != nil {
@@ -123,7 +121,7 @@ func TestUserSave(t *testing.T) {
 }
 
 func TestUserSaveError(t *testing.T) {
-	mockDb := test.SetupMockDb()
+	mockDb := SetupMockDb()
 
 	user := NewUser(testUser.Username)
 	mockDb.Error = errors.New("test_error")
@@ -188,7 +186,7 @@ func TestValidatePasswordError(t *testing.T) {
 }
 
 func TestGetPoints(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 	createTestUser(testUser)
 
 	user := NewUser(testUser.Username)
@@ -204,7 +202,7 @@ func TestGetPoints(t *testing.T) {
 }
 
 func TestGetPointsError(t *testing.T) {
-	mockDb := test.SetupMockDb()
+	mockDb := SetupMockDb()
 	createTestUser(testUser)
 
 	mockDb.Error = errors.New("test_error")

--- a/src/models/challenges.go
+++ b/src/models/challenges.go
@@ -3,7 +3,6 @@ package models
 import (
 	"gorm.io/gorm"
 	"strconv"
-	"the-wedding-game-api/db"
 	apperrors "the-wedding-game-api/errors"
 	"the-wedding-game-api/types"
 )
@@ -62,24 +61,25 @@ func CreateNewChallenge(createChallengeRequest types.CreateChallengeRequest) (Ch
 }
 
 func (challenge Challenge) Save() (Challenge, error) {
-	conn := db.GetConnection()
+	conn := GetConnection()
 	if err := conn.Create(&challenge).GetError(); err != nil {
 		return Challenge{}, err
 	}
 	return challenge, nil
 }
 
-func GetAllChallenges() ([]Challenge, error) {
-	conn := db.GetConnection()
-	var challenges []Challenge
-	if err := conn.Where("status = ?", types.ActiveChallenge).Find(&challenges).GetError(); err != nil {
-		return nil, err
+func GetAllChallenges(showInactive bool) ([]Challenge, error) {
+	conn := GetConnection()
+	challenges, err := conn.GetAllChallenges(showInactive)
+	if err != nil {
+		return []Challenge{}, err
 	}
+
 	return challenges, nil
 }
 
 func GetChallengeByID(id uint) (Challenge, error) {
-	conn := db.GetConnection()
+	conn := GetConnection()
 	var challenge Challenge
 	if err := conn.First(&challenge, id).GetError(); err != nil {
 		if apperrors.IsRecordNotFoundError(err) {

--- a/src/models/challenges_test.go
+++ b/src/models/challenges_test.go
@@ -3,8 +3,6 @@ package models
 import (
 	"errors"
 	"testing"
-	test "the-wedding-game-api/_tests"
-	"the-wedding-game-api/db"
 	"the-wedding-game-api/types"
 )
 
@@ -51,7 +49,7 @@ func TestNewChallenge(t *testing.T) {
 }
 
 func TestCreateNewChallengeTypeUpload(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 
 	createChallengeRequest := types.CreateChallengeRequest{
 		Name:        testChallenge1.Name,
@@ -105,7 +103,7 @@ func TestCreateNewChallengeTypeUpload(t *testing.T) {
 	}
 
 	//Ensure an answer is not created for an upload photo challenge
-	mockDb := db.GetConnection()
+	mockDb := GetConnection()
 	var answer Answer
 	err = mockDb.First(&answer, "challenge_id = ?", challenge.ID).GetError()
 	if err == nil {
@@ -118,7 +116,7 @@ func TestCreateNewChallengeTypeUpload(t *testing.T) {
 }
 
 func TestCreateNewChallengeTypeAnswer(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 
 	createChallengeRequest := types.CreateChallengeRequest{
 		Name:        testChallenge1.Name,
@@ -173,7 +171,7 @@ func TestCreateNewChallengeTypeAnswer(t *testing.T) {
 	}
 
 	//Ensure answer is created in database
-	mockDb := db.GetConnection()
+	mockDb := GetConnection()
 	var answer Answer
 	err = mockDb.First(&answer).GetError()
 	if err != nil {
@@ -186,7 +184,7 @@ func TestCreateNewChallengeTypeAnswer(t *testing.T) {
 }
 
 func TestCreateNewChallengeError(t *testing.T) {
-	mockDb := test.SetupMockDb()
+	mockDb := SetupMockDb()
 
 	createChallengeRequest := types.CreateChallengeRequest{
 		Name:        testChallenge1.Name,
@@ -209,7 +207,7 @@ func TestCreateNewChallengeError(t *testing.T) {
 }
 
 func TestChallengeSave(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 
 	challenge := NewChallenge(testChallenge1.Name, testChallenge1.Description, testChallenge1.Points, testChallenge1.Image,
 		testChallenge1.Type, testChallenge1.Status)
@@ -264,7 +262,7 @@ func TestChallengeSave(t *testing.T) {
 }
 
 func TestChallengeSaveError(t *testing.T) {
-	mockDb := test.SetupMockDb()
+	mockDb := SetupMockDb()
 
 	challenge := NewChallenge(testChallenge1.Name, testChallenge1.Description, testChallenge1.Points, testChallenge1.Image,
 		testChallenge1.Type, testChallenge1.Status)
@@ -281,7 +279,7 @@ func TestChallengeSaveError(t *testing.T) {
 }
 
 func TestGetAllChallenges(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 
 	_, err := testChallenge1.Save()
 	if err != nil {
@@ -295,7 +293,7 @@ func TestGetAllChallenges(t *testing.T) {
 		return
 	}
 
-	challenges, err := GetAllChallenges()
+	challenges, err := GetAllChallenges(false)
 	if err != nil {
 		t.Errorf("expected nil but got %s", err.Error())
 		return
@@ -303,6 +301,7 @@ func TestGetAllChallenges(t *testing.T) {
 
 	if len(challenges) != 2 {
 		t.Errorf("expected 2 but got %d", len(challenges))
+		return
 	}
 	if challenges[0].Name != testChallenge1.Name {
 		t.Errorf("expected test_challenge1 but got %s", challenges[0].Name)
@@ -313,10 +312,10 @@ func TestGetAllChallenges(t *testing.T) {
 }
 
 func TestGetAllChallengesError(t *testing.T) {
-	mockDb := test.SetupMockDb()
+	mockDb := SetupMockDb()
 
 	mockDb.Error = errors.New("test_error")
-	_, err := GetAllChallenges()
+	_, err := GetAllChallenges(false)
 	if err == nil {
 		t.Errorf("expected error but got nil")
 		return
@@ -328,9 +327,9 @@ func TestGetAllChallengesError(t *testing.T) {
 }
 
 func TestGetAllChallengesEmpty(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 
-	challenges, err := GetAllChallenges()
+	challenges, err := GetAllChallenges(false)
 	if err != nil {
 		t.Errorf("expected nil but got %s", err.Error())
 		return
@@ -342,7 +341,7 @@ func TestGetAllChallengesEmpty(t *testing.T) {
 }
 
 func TestGetChallengeByIDTypeUpload(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 
 	_, err := testChallenge1.Save()
 	if err != nil {
@@ -377,7 +376,7 @@ func TestGetChallengeByIDTypeUpload(t *testing.T) {
 }
 
 func TestGetChallengeByIDTypeAnswer(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 
 	_, err := testChallenge2.Save()
 	if err != nil {
@@ -412,7 +411,7 @@ func TestGetChallengeByIDTypeAnswer(t *testing.T) {
 }
 
 func TestGetChallengeByIDError(t *testing.T) {
-	mockDb := test.SetupMockDb()
+	mockDb := SetupMockDb()
 	_, err := testChallenge1.Save()
 	if err != nil {
 		t.Errorf("expected nil but got %s", err.Error())
@@ -432,7 +431,7 @@ func TestGetChallengeByIDError(t *testing.T) {
 }
 
 func TestGetChallengeByIDNotFound(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 
 	_, err := GetChallengeByID(1)
 	if err == nil {

--- a/src/models/db.go
+++ b/src/models/db.go
@@ -1,4 +1,4 @@
-package db
+package models
 
 import (
 	"the-wedding-game-api/types"
@@ -12,6 +12,7 @@ type DatabaseInterface interface {
 	First(dest interface{}, where ...interface{}) DatabaseInterface
 	Create(value interface{}) DatabaseInterface
 	Find(dest interface{}, where ...interface{}) DatabaseInterface
+	GetAllChallenges(showInactive bool) ([]Challenge, error)
 	GetPointsForUser(userId uint) (uint, error)
 	GetLeaderboard() ([]types.LeaderboardEntry, error)
 	GetGallery() ([]types.GalleryItem, error)

--- a/src/models/db_mock.go
+++ b/src/models/db_mock.go
@@ -1,10 +1,9 @@
-package test
+package models
 
 import (
 	"errors"
 	"reflect"
 	"strings"
-	"the-wedding-game-api/db"
 	apperrors "the-wedding-game-api/errors"
 	"the-wedding-game-api/types"
 )
@@ -14,15 +13,15 @@ type MockDB struct {
 	Error error
 }
 
-func (m *MockDB) GetSession() db.DatabaseInterface {
+func (m *MockDB) GetSession() DatabaseInterface {
 	return m
 }
 
-func (m *MockDB) Where(_ interface{}, _ ...interface{}) db.DatabaseInterface {
+func (m *MockDB) Where(_ interface{}, _ ...interface{}) DatabaseInterface {
 	return m
 }
 
-func (m *MockDB) First(dest interface{}, _ ...interface{}) db.DatabaseInterface {
+func (m *MockDB) First(dest interface{}, _ ...interface{}) DatabaseInterface {
 	if len(m.items) == 0 {
 		destValue := reflect.ValueOf(dest)
 		m.Error = errors.New("record not found: " + destValue.Type().String())
@@ -45,12 +44,12 @@ func (m *MockDB) First(dest interface{}, _ ...interface{}) db.DatabaseInterface 
 	return m
 }
 
-func (m *MockDB) Create(value interface{}) db.DatabaseInterface {
+func (m *MockDB) Create(value interface{}) DatabaseInterface {
 	m.items = append(m.items, value)
 	return m
 }
 
-func (m *MockDB) Find(dest interface{}, _ ...interface{}) db.DatabaseInterface {
+func (m *MockDB) Find(dest interface{}, _ ...interface{}) DatabaseInterface {
 	destValue := reflect.ValueOf(dest)
 	if destValue.Kind() != reflect.Ptr || destValue.IsNil() {
 		m.Error = errors.New("dest must be a non-nil pointer")
@@ -74,6 +73,17 @@ func (m *MockDB) Find(dest interface{}, _ ...interface{}) db.DatabaseInterface {
 
 	destValue.Elem().Set(sliceValue)
 	return m
+}
+
+func (m *MockDB) GetAllChallenges(_ bool) ([]Challenge, error) {
+	var challenges []Challenge
+
+	m.Find(&challenges)
+	if m.Error != nil {
+		return nil, apperrors.NewDatabaseError(m.Error.Error())
+	}
+
+	return challenges, nil
 }
 
 func (m *MockDB) GetPointsForUser(_ uint) (uint, error) {

--- a/src/models/gallery.go
+++ b/src/models/gallery.go
@@ -1,13 +1,12 @@
 package models
 
 import (
-	"the-wedding-game-api/db"
 	"the-wedding-game-api/types"
 	"the-wedding-game-api/utils"
 )
 
 func GetGalleryImages() ([]types.GalleryItem, error) {
-	conn := db.GetConnection()
+	conn := GetConnection()
 	gallery, err := conn.GetGallery()
 	if err != nil {
 		return nil, err

--- a/src/models/gallery_test.go
+++ b/src/models/gallery_test.go
@@ -3,7 +3,6 @@ package models
 import (
 	"errors"
 	"testing"
-	test "the-wedding-game-api/_tests"
 	apperrors "the-wedding-game-api/errors"
 	"the-wedding-game-api/types"
 )
@@ -14,7 +13,7 @@ var (
 )
 
 func TestGetGalleryImages(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 
 	gallery, err := GetGalleryImages()
 	if err != nil {
@@ -43,7 +42,7 @@ func TestGetGalleryImages(t *testing.T) {
 }
 
 func TestGetGalleryImagesError(t *testing.T) {
-	mockDb := test.SetupMockDb()
+	mockDb := SetupMockDb()
 	mockDb.Error = errors.New("test_error")
 
 	_, err := GetGalleryImages()

--- a/src/models/gorm_db.go
+++ b/src/models/gorm_db.go
@@ -1,4 +1,4 @@
-package db
+package models
 
 import (
 	"errors"
@@ -49,6 +49,24 @@ func (p *database) Find(dest interface{}, where ...interface{}) DatabaseInterfac
 	p.initialConnection.Error = p.db.Error
 	p.db = p.initialConnection
 	return p
+}
+
+func (p *database) GetAllChallenges(showInactive bool) ([]Challenge, error) {
+	var challenges []Challenge
+	if showInactive {
+		p.db = p.db.Raw(`
+			SELECT ID, Name, Description, Points, Image, Type, Status
+			FROM challenges
+		`).Scan(&challenges)
+	} else {
+		p.db = p.db.Raw(`
+			SELECT ID, Name, Description, Points, Image, Type, Status
+			FROM challenges
+			WHERE status = ?
+		`, types.ActiveChallenge).Scan(&challenges)
+	}
+
+	return challenges, nil
 }
 
 func (p *database) GetPointsForUser(userId uint) (uint, error) {

--- a/src/models/models_test.go
+++ b/src/models/models_test.go
@@ -1,0 +1,9 @@
+package models
+
+func SetupMockDb() *MockDB {
+	mockDB := &MockDB{}
+	GetConnection = func() DatabaseInterface {
+		return mockDB
+	}
+	return mockDB
+}

--- a/src/models/submissions.go
+++ b/src/models/submissions.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"gorm.io/gorm"
-	"the-wedding-game-api/db"
 	apperrors "the-wedding-game-api/errors"
 	"the-wedding-game-api/types"
 )
@@ -26,7 +25,7 @@ func NewSubmission(userId uint, challengeId uint, answer string) Submission {
 }
 
 func (s *Submission) Save() (*Submission, error) {
-	conn := db.GetConnection()
+	conn := GetConnection()
 	if err := conn.Create(s).GetError(); err != nil {
 		return nil, err
 	}
@@ -34,7 +33,7 @@ func (s *Submission) Save() (*Submission, error) {
 }
 
 func IsChallengeCompleted(userId uint, challengeId uint) (bool, error) {
-	conn := db.GetConnection()
+	conn := GetConnection()
 	var submission Submission
 	err := conn.Where("user_id = ? AND challenge_id = ?", userId, challengeId).First(&submission).GetError()
 	if err != nil {
@@ -47,7 +46,7 @@ func IsChallengeCompleted(userId uint, challengeId uint) (bool, error) {
 }
 
 func GetCompletedChallenges(userId uint) ([]Submission, error) {
-	conn := db.GetConnection()
+	conn := GetConnection()
 	var submissions []Submission
 	if err := conn.Where("user_id = ?", userId).Find(&submissions).GetError(); err != nil {
 		return nil, err
@@ -56,7 +55,7 @@ func GetCompletedChallenges(userId uint) ([]Submission, error) {
 }
 
 func GetLeaderboard() ([]types.LeaderboardEntry, error) {
-	conn := db.GetConnection()
+	conn := GetConnection()
 	leaderboard, err := conn.GetLeaderboard()
 	if err != nil {
 		return nil, err

--- a/src/models/submissions_test.go
+++ b/src/models/submissions_test.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"reflect"
 	"testing"
-	test "the-wedding-game-api/_tests"
-	"the-wedding-game-api/db"
 	apperrors "the-wedding-game-api/errors"
 	"the-wedding-game-api/types"
 )
@@ -37,7 +35,7 @@ func TestNewSubmission(t *testing.T) {
 }
 
 func TestSubmissionSave(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 
 	submission := &testSubmission1
 	savedSubmission, err := submission.Save()
@@ -55,7 +53,7 @@ func TestSubmissionSave(t *testing.T) {
 		t.Errorf("expected %s but got %s", testSubmission1.Answer, savedSubmission.Answer)
 	}
 
-	mockDb := db.GetConnection()
+	mockDb := GetConnection()
 	var submissionFromDb Submission
 	if err := mockDb.First(&submissionFromDb, savedSubmission.ID).GetError(); err != nil {
 		t.Errorf("expected nil but got %v", err)
@@ -73,7 +71,7 @@ func TestSubmissionSave(t *testing.T) {
 }
 
 func TestSubmissionSaveError(t *testing.T) {
-	mockDb := test.SetupMockDb()
+	mockDb := SetupMockDb()
 	mockDb.Error = errors.New("test_error")
 
 	_, err := testSubmission1.Save()
@@ -90,7 +88,7 @@ func TestSubmissionSaveError(t *testing.T) {
 }
 
 func TestIsChallengeCompleted(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 
 	submission := &testSubmission1
 	_, err := submission.Save()
@@ -108,7 +106,7 @@ func TestIsChallengeCompleted(t *testing.T) {
 }
 
 func TestIsChallengeCompletedNotFound(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 
 	isCompleted, err := IsChallengeCompleted(testSubmission1.UserID, testSubmission1.ChallengeID)
 	if err != nil {
@@ -121,7 +119,7 @@ func TestIsChallengeCompletedNotFound(t *testing.T) {
 }
 
 func TestIsChallengeCompletedError(t *testing.T) {
-	mockDb := test.SetupMockDb()
+	mockDb := SetupMockDb()
 
 	_, err := testSubmission1.Save()
 	if err != nil {
@@ -144,7 +142,7 @@ func TestIsChallengeCompletedError(t *testing.T) {
 }
 
 func TestGetCompletedChallenges(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 
 	_, err := testSubmission1.Save()
 	if err != nil {
@@ -184,7 +182,7 @@ func TestGetCompletedChallenges(t *testing.T) {
 }
 
 func TestGetCompletedChallengesError(t *testing.T) {
-	mockDb := test.SetupMockDb()
+	mockDb := SetupMockDb()
 
 	_, err := testSubmission1.Save()
 	if err != nil {
@@ -209,7 +207,7 @@ func TestGetCompletedChallengesError(t *testing.T) {
 }
 
 func TestGetCompletedChallengesNotFound(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 
 	submissions, err := GetCompletedChallenges(testSubmission1.UserID)
 	if err != nil {
@@ -223,7 +221,7 @@ func TestGetCompletedChallengesNotFound(t *testing.T) {
 }
 
 func TestGetLeaderboard(t *testing.T) {
-	test.SetupMockDb()
+	SetupMockDb()
 
 	leaderboard, err := GetLeaderboard()
 	if err != nil {
@@ -243,7 +241,7 @@ func TestGetLeaderboard(t *testing.T) {
 }
 
 func TestGetLeaderboardError(t *testing.T) {
-	mockDb := test.SetupMockDb()
+	mockDb := SetupMockDb()
 	mockDb.Error = errors.New("test_error")
 
 	_, err := GetLeaderboard()

--- a/src/routes/challenges.go
+++ b/src/routes/challenges.go
@@ -87,7 +87,7 @@ func GetAllChallenges(c *gin.Context) {
 		return
 	}
 
-	challengesArr, err := models.GetAllChallenges()
+	challengesArr, err := models.GetAllChallenges(false)
 	if err != nil {
 		_ = c.Error(err)
 		return


### PR DESCRIPTION
This pull request focuses on refactoring the integration tests and removing the `db` package dependency in favor of the `models` package. The most important changes include updating the import statements and replacing calls to `db.ResetConnection()` with `models.ResetConnection()`.

### Refactoring Integration Tests:

* [`src/integration_tests/auth_test.go`](diffhunk://#diff-8aed07535d089c9799245c29dbbb67d4121bf7a3da274b28729b8c88df4013cdL10-R15): Replaced `db.ResetConnection()` with `models.ResetConnection()` in multiple test functions. [[1]](diffhunk://#diff-8aed07535d089c9799245c29dbbb67d4121bf7a3da274b28729b8c88df4013cdL10-R15) [[2]](diffhunk://#diff-8aed07535d089c9799245c29dbbb67d4121bf7a3da274b28729b8c88df4013cdL61-R60) [[3]](diffhunk://#diff-8aed07535d089c9799245c29dbbb67d4121bf7a3da274b28729b8c88df4013cdL111-R110) [[4]](diffhunk://#diff-8aed07535d089c9799245c29dbbb67d4121bf7a3da274b28729b8c88df4013cdL185-R184) [[5]](diffhunk://#diff-8aed07535d089c9799245c29dbbb67d4121bf7a3da274b28729b8c88df4013cdL224-R223) [[6]](diffhunk://#diff-8aed07535d089c9799245c29dbbb67d4121bf7a3da274b28729b8c88df4013cdL259-R258)
* [`src/integration_tests/challenges_test.go`](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL9-R14): Replaced `db.ResetConnection()` with `models.ResetConnection()` in multiple test functions. [[1]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL9-R14) [[2]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL82-R81) [[3]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL149-R148) [[4]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL223-R222) [[5]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL251-R250) [[6]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL279-R278) [[7]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL299-R298) [[8]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL319-R318) [[9]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL385-R384) [[10]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL440-R439) [[11]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL496-R495) [[12]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL523-R522) [[13]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL544-R543) [[14]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL565-R564) [[15]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL585-R584) [[16]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL605-R604) [[17]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL632-R631) [[18]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL659-R658) [[19]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL686-R685) [[20]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL713-R712) [[21]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL740-R739) [[22]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL767-R766) [[23]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL794-R793) [[24]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL821-R820) [[25]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL848-R847) [[26]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL876-R875) [[27]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL903-R902) [[28]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL932-R931) [[29]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eR984) [[30]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL1046-R1046) [[31]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL1131-R1131) [[32]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL1251-R1251)

### Removal of `db` package:

* [`src/_tests/test_utils.go`](diffhunk://#diff-e8ec8d46f70ffb930800de7a19eb4267a9a1495f8ca7886f5d3847e6315857a0L8-L19): Removed the `db` package import and the `SetupMockDb` function.