### PR TITLE
Add admin endpoint to retrieve all challenges

### DIFF
--- a/src/middleware/auth.go
+++ b/src/middleware/auth.go
@@ -32,3 +32,11 @@ func CheckIsAdmin(c *gin.Context) error {
 	}
 	return nil
 }
+
+func IsAdmin(c *gin.Context) {
+	if err := CheckIsAdmin(c); err != nil {
+		handleError(c, err)
+		return
+	}
+	c.Next()
+}

--- a/src/middleware/error_handler.go
+++ b/src/middleware/error_handler.go
@@ -14,47 +14,94 @@ func ErrorHandler(c *gin.Context) {
 	err := c.Errors.Last()
 
 	if err != nil {
-		if apperrors.IsAccessTokenNotFoundError(err.Err) || apperrors.IsAuthorizationError(err.Err) {
-			c.JSON(http.StatusForbidden, gin.H{
-				"status":  "error",
-				"message": "access denied",
-			})
-			c.Abort()
-			return
-		}
+		handleError(c, err.Err)
+		return
+		//if apperrors.IsAccessTokenNotFoundError(err.Err) || apperrors.IsAuthorizationError(err.Err) {
+		//	c.JSON(http.StatusForbidden, gin.H{
+		//		"status":  "error",
+		//		"message": "access denied",
+		//	})
+		//	c.Abort()
+		//	return
+		//}
+		//
+		//if apperrors.IsAuthenticationError(err.Err) {
+		//	c.JSON(http.StatusUnauthorized, gin.H{
+		//		"status":  "error",
+		//		"message": err.Err.Error(),
+		//	})
+		//	c.Abort()
+		//	return
+		//}
+		//
+		//if apperrors.IsValidationError(err.Err) || strings.Contains(err.Err.Error(), "Error:Field validation for") {
+		//	c.JSON(http.StatusBadRequest, gin.H{
+		//		"status":  "error",
+		//		"message": err.Err.Error(),
+		//	})
+		//	c.Abort()
+		//	return
+		//}
+		//
+		//if apperrors.IsNotFoundError(err.Err) {
+		//	c.JSON(http.StatusNotFound, gin.H{
+		//		"status":  "error",
+		//		"message": err.Err.Error(),
+		//	})
+		//	c.Abort()
+		//	return
+		//}
+		//
+		//log.Println(err)
+		//c.JSON(http.StatusInternalServerError, gin.H{
+		//	"status":  "error",
+		//	"message": "An unexpected error occurred.",
+		//})
+		//c.Abort()
+	}
+}
 
-		if apperrors.IsAuthenticationError(err.Err) {
-			c.JSON(http.StatusUnauthorized, gin.H{
-				"status":  "error",
-				"message": err.Err.Error(),
-			})
-			c.Abort()
-			return
-		}
-
-		if apperrors.IsValidationError(err.Err) || strings.Contains(err.Err.Error(), "Error:Field validation for") {
-			c.JSON(http.StatusBadRequest, gin.H{
-				"status":  "error",
-				"message": err.Err.Error(),
-			})
-			c.Abort()
-			return
-		}
-
-		if apperrors.IsNotFoundError(err.Err) {
-			c.JSON(http.StatusNotFound, gin.H{
-				"status":  "error",
-				"message": err.Err.Error(),
-			})
-			c.Abort()
-			return
-		}
-
-		log.Println(err)
-		c.JSON(http.StatusInternalServerError, gin.H{
+func handleError(c *gin.Context, err error) {
+	if apperrors.IsAccessTokenNotFoundError(err) || apperrors.IsAuthorizationError(err) {
+		c.JSON(http.StatusForbidden, gin.H{
 			"status":  "error",
-			"message": "An unexpected error occurred.",
+			"message": "access denied",
 		})
 		c.Abort()
+		return
 	}
+
+	if apperrors.IsAuthenticationError(err) {
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"status":  "error",
+			"message": err.Error(),
+		})
+		c.Abort()
+		return
+	}
+
+	if apperrors.IsValidationError(err) || strings.Contains(err.Error(), "Error:Field validation for") {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"status":  "error",
+			"message": err.Error(),
+		})
+		c.Abort()
+		return
+	}
+
+	if apperrors.IsNotFoundError(err) {
+		c.JSON(http.StatusNotFound, gin.H{
+			"status":  "error",
+			"message": err.Error(),
+		})
+		c.Abort()
+		return
+	}
+
+	log.Println(err)
+	c.JSON(http.StatusInternalServerError, gin.H{
+		"status":  "error",
+		"message": "An unexpected error occurred.",
+	})
+	c.Abort()
 }

--- a/src/routes/challenges.go
+++ b/src/routes/challenges.go
@@ -120,6 +120,31 @@ func GetAllChallenges(c *gin.Context) {
 	return
 }
 
+func GetAllChallengesAdmin(c *gin.Context) {
+	challengesArr, err := models.GetAllChallenges(true)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	var response types.GetChallengesAdminResponse
+	response.Challenges = make([]types.GetChallengeAdminResponse, len(challengesArr))
+	for i, challenge := range challengesArr {
+		response.Challenges[i] = types.GetChallengeAdminResponse{
+			Id:          challenge.ID,
+			Name:        challenge.Name,
+			Description: challenge.Description,
+			Points:      challenge.Points,
+			Image:       challenge.Image,
+			Status:      challenge.Status,
+			Type:        challenge.Type,
+		}
+	}
+
+	c.IndentedJSON(http.StatusOK, response)
+	return
+}
+
 func VerifyAnswer(c *gin.Context) {
 	user, err := middleware.GetCurrentUser(c)
 	if err != nil {

--- a/src/routes/router.go
+++ b/src/routes/router.go
@@ -31,5 +31,7 @@ func GetRouter() *gin.Engine {
 
 	router.POST("/upload", HandleImageUpload)
 
+	router.GET("/admin/challenges", middleware.IsAdmin, GetAllChallengesAdmin)
+
 	return router
 }

--- a/src/types/challenges.go
+++ b/src/types/challenges.go
@@ -55,3 +55,17 @@ type VerifyAnswerRequest struct {
 type VerifyAnswerResponse struct {
 	Correct bool `json:"correct"`
 }
+
+type GetChallengesAdminResponse struct {
+	Challenges []GetChallengeAdminResponse `json:"challenges"`
+}
+
+type GetChallengeAdminResponse struct {
+	Id          uint            `json:"id"`
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Points      uint            `json:"points"`
+	Image       string          `json:"image"`
+	Status      ChallengeStatus `json:"status"`
+	Type        ChallengeType   `json:"type"`
+}


### PR DESCRIPTION
Fixes: https://github.com/the-wedding-game/the-wedding-game-api/issues/45

This pull request introduces new functionality for handling admin-specific challenge operations and refactors error handling in the middleware. The most important changes include adding new test cases, creating an admin-specific endpoint for fetching challenges, and refactoring the error handling logic.

### New Functionality:
* [`src/routes/challenges.go`](diffhunk://#diff-2a6e357e465646a4ddd1cd8f9aaf7dc4b6d6eac7588203563810e796f17ddf20R123-R147): Added `GetAllChallengesAdmin` function to fetch all challenges for admin users.
* [`src/routes/router.go`](diffhunk://#diff-0f2146da3a3dc9bfad9f4b50ed7113dd61e2c1313989cdf2ed06404d564832a4R34-R35): Added a new route `/admin/challenges` which uses the `IsAdmin` middleware to ensure only admin users can access it.
* [`src/types/challenges.go`](diffhunk://#diff-caa4dea85de27f44a8ba4498682a662fee6788ff8499df727f42525c2ff70370R58-R71): Added new types `GetChallengesAdminResponse` and `GetChallengeAdminResponse` to structure the response for the admin challenges endpoint.

### Testing:
* [`src/integration_tests/challenges_test.go`](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eR1613-R1768): Added multiple test cases to verify the behavior of the new admin challenges endpoint, including scenarios for valid admin access, non-admin access, missing access token, and invalid access token.

### Middleware Enhancements:
* [`src/middleware/auth.go`](diffhunk://#diff-4851ebb16fba456b5e4494b55ad8110c54541d474afced10142fe9d767bc2987R35-R42): Introduced `IsAdmin` middleware to check if the user is an admin before proceeding with the request.
* [`src/middleware/error_handler.go`](diffhunk://#diff-00f60cb3ed9df70184fdbf25454ff11dfb60c688bfb6b5c2c67a1d151855e8b1L17-R65): Refactored the `ErrorHandler` function to use a new `handleError` function for better error management and code readability. [[1]](diffhunk://#diff-00f60cb3ed9df70184fdbf25454ff11dfb60c688bfb6b5c2c67a1d151855e8b1L17-R65) [[2]](diffhunk://#diff-00f60cb3ed9df70184fdbf25454ff11dfb60c688bfb6b5c2c67a1d151855e8b1L26-R95) [[3]](diffhunk://#diff-00f60cb3ed9df70184fdbf25454ff11dfb60c688bfb6b5c2c67a1d151855e8b1L60)