### PR TITLE
Add endpoint to update challenges

### DIFF
--- a/src/middleware/validators/challenges.go
+++ b/src/middleware/validators/challenges.go
@@ -50,6 +50,29 @@ func ValidateGetChallengeByIdRequest(c *gin.Context) (uint, error) {
 	return uint(id), nil
 }
 
+func ValidateUpdateChallengeRequest(c *gin.Context) (uint, types.UpdateChallengeRequest, error) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return 0, types.UpdateChallengeRequest{}, apperrors.NewValidationError("invalid challenge id")
+	}
+
+	var updateChallengeRequest types.UpdateChallengeRequest
+	if err := c.BindJSON(&updateChallengeRequest); err != nil {
+		return 0, types.UpdateChallengeRequest{}, apperrors.NewValidationError(err.Error())
+	}
+
+	err = validate.Struct(&updateChallengeRequest)
+	if err != nil {
+		return 0, types.UpdateChallengeRequest{}, apperrors.NewValidationError(err.Error())
+	}
+
+	if !utils.IsURLStrict(updateChallengeRequest.Image) {
+		return 0, types.UpdateChallengeRequest{}, apperrors.NewValidationError("invalid image url")
+	}
+
+	return uint(id), updateChallengeRequest, nil
+}
+
 func ValidateVerifyAnswerRequest(c *gin.Context) (uint, types.VerifyAnswerRequest, error) {
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {

--- a/src/models/answers.go
+++ b/src/models/answers.go
@@ -79,19 +79,10 @@ func verifyAnswerForPhoto(answer string) (bool, error) {
 
 func (answer Answer) Update() (Answer, error) {
 	conn := GetConnection()
-	updatedAnswer, err := conn.UpdateAnswer(answer.ChallengeID, answer.Value)
-	if err != nil {
-		return Answer{}, err
-	}
-
-	return updatedAnswer, nil
+	return conn.UpdateAnswer(answer.ChallengeID, answer.Value)
 }
 
-func DeleteAnswer(challengeId uint) (bool, error) {
+func DeleteAnswer(challengeId uint) error {
 	conn := GetConnection()
-	err := conn.DeleteAnswer(challengeId)
-	if err != nil {
-		return false, err
-	}
-	return true, nil
+	return conn.DeleteAnswer(challengeId)
 }

--- a/src/models/answers.go
+++ b/src/models/answers.go
@@ -76,3 +76,22 @@ func verifyAnswerForPhoto(answer string) (bool, error) {
 
 	return true, nil
 }
+
+func (answer Answer) Update() (Answer, error) {
+	conn := GetConnection()
+	updatedAnswer, err := conn.UpdateAnswer(answer.ChallengeID, answer.Value)
+	if err != nil {
+		return Answer{}, err
+	}
+
+	return updatedAnswer, nil
+}
+
+func DeleteAnswer(challengeId uint) (bool, error) {
+	conn := GetConnection()
+	err := conn.DeleteAnswer(challengeId)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/src/models/answers_test.go
+++ b/src/models/answers_test.go
@@ -9,6 +9,7 @@ import (
 
 var (
 	testChallenge123 = Challenge{ID: 123, Name: "name", Description: "description", Points: 10, Type: types.AnswerQuestionChallenge, Status: types.ActiveChallenge}
+	testChallenge321 = Challenge{ID: 123, Name: "name", Description: "description", Points: 10, Type: types.UploadPhotoChallenge, Status: types.ActiveChallenge}
 	testAnswer123    = Answer{ChallengeID: 123, Value: "answer"}
 	testAnswer34324  = Answer{ChallengeID: 34324, Value: "another answer"}
 )
@@ -146,6 +147,145 @@ func TestVerifyAnswerError(t *testing.T) {
 	createTestChallenge(testChallenge123)
 	createTestAnswer(testAnswer123)
 	_, err := VerifyAnswer(testAnswer123.ChallengeID, testAnswer123.Value)
+	if err == nil {
+		t.Errorf("expected error but got nil")
+		return
+	}
+
+	if !apperrors.IsDatabaseError(err) {
+		t.Errorf("expected database error but got %s", err.Error())
+	}
+	if err.Error() != "test_error" {
+		t.Errorf("expected test_error but got %s", err.Error())
+	}
+}
+
+func TestVerifyAnswerForPhoto(t *testing.T) {
+	SetupMockDb()
+	createTestChallenge(testChallenge321)
+
+	isCorrect, err := VerifyAnswer(testChallenge321.ID, "https://www.google.com")
+	if err != nil {
+		t.Errorf("expected nil but got %s", err.Error())
+		return
+	}
+
+	if !isCorrect {
+		t.Errorf("expected true but got false")
+	}
+}
+
+func TestVerifyAnswerForPhotoInvalidURL(t *testing.T) {
+	SetupMockDb()
+	createTestChallenge(testChallenge321)
+
+	_, err := VerifyAnswer(testChallenge321.ID, "invalid url")
+	if err == nil {
+		t.Errorf("expected error but got nil")
+		return
+	}
+
+	if !apperrors.IsValidationError(err) {
+		t.Errorf("expected validation error but got %s", err.Error())
+	}
+	if err.Error() != "invalid image url" {
+		t.Errorf("expected invalid image url but got %s", err.Error())
+	}
+}
+
+func TestUpdateAnswer(t *testing.T) {
+	SetupMockDb()
+
+	newAnswer := Answer{
+		ChallengeID: testAnswer123.ChallengeID,
+		Value:       "new answer",
+	}
+	updatedAnswer, err := newAnswer.Update()
+	if err != nil {
+		t.Errorf("expected nil but got %s", err.Error())
+		return
+	}
+
+	if updatedAnswer.Value != newAnswer.Value {
+		t.Errorf("expected %s but got %s", newAnswer.Value, updatedAnswer.Value)
+	}
+}
+
+func TestUpdateAnswerNotFound(t *testing.T) {
+	SetupMockDb()
+
+	newAnswer := Answer{
+		ChallengeID: 999,
+		Value:       "new answer",
+	}
+	_, err := newAnswer.Update()
+	if err == nil {
+		t.Errorf("expected error but got nil")
+		return
+	}
+
+	if !apperrors.IsRecordNotFoundError(err) {
+		t.Errorf("expected not found error but got %s", err.Error())
+	}
+	if err.Error() != "Answer with key 999 not found" {
+		t.Errorf("expected Answer with key 999 not found. but got %s", err.Error())
+	}
+}
+
+func TestUpdateAnswerError(t *testing.T) {
+	mockDB := SetupMockDb()
+	mockDB.Error = errors.New("test_error")
+
+	newAnswer := Answer{
+		ChallengeID: testAnswer123.ChallengeID,
+		Value:       "new answer",
+	}
+	_, err := newAnswer.Update()
+	if err == nil {
+		t.Errorf("expected error but got nil")
+		return
+	}
+
+	if !apperrors.IsDatabaseError(err) {
+		t.Errorf("expected database error but got %s", err.Error())
+	}
+	if err.Error() != "test_error" {
+		t.Errorf("expected test_error but got %s", err.Error())
+	}
+}
+
+func TestDeleteAnswer(t *testing.T) {
+	SetupMockDb()
+
+	err := DeleteAnswer(testAnswer123.ChallengeID)
+	if err != nil {
+		t.Errorf("expected nil but got %s", err.Error())
+		return
+	}
+}
+
+func TestDeleteAnswerNotFound(t *testing.T) {
+	SetupMockDb()
+
+	err := DeleteAnswer(999)
+	if err == nil {
+		t.Errorf("expected error but got nil")
+		return
+	}
+
+	if !apperrors.IsRecordNotFoundError(err) {
+		t.Errorf("expected not found error but got %s", err.Error())
+	}
+	if err.Error() != "Answer with key 999 not found" {
+		t.Errorf("expected Answer with key 999 not found but got %s", err.Error())
+	}
+}
+
+func TestDeleteAnswerError(t *testing.T) {
+	mockDB := SetupMockDb()
+	mockDB.Error = errors.New("test_error")
+
+	err := DeleteAnswer(testAnswer123.ChallengeID)
 	if err == nil {
 		t.Errorf("expected error but got nil")
 		return

--- a/src/models/challenges.go
+++ b/src/models/challenges.go
@@ -118,8 +118,7 @@ func (challenge Challenge) Update(updateChallengeRequest types.UpdateChallengeRe
 
 	// If challenge was previously an AnswerQuestionChallenge, delete the answer
 	if updatedChallenge.Type == types.UploadPhotoChallenge && challenge.Type == types.AnswerQuestionChallenge {
-		_, err := DeleteAnswer(challenge.ID)
-		if err != nil {
+		if err := DeleteAnswer(challenge.ID); err != nil {
 			return Challenge{}, err
 		}
 	}
@@ -129,22 +128,12 @@ func (challenge Challenge) Update(updateChallengeRequest types.UpdateChallengeRe
 
 func (challenge Challenge) hasSubmissions() (bool, error) {
 	conn := GetConnection()
-	hasSubmissions, err := conn.HasSubmissions(challenge.ID)
-	if err != nil {
-		return false, err
-	}
-
-	return hasSubmissions, nil
+	return conn.HasSubmissions(challenge.ID)
 }
 
 func GetAllChallenges(showInactive bool) ([]Challenge, error) {
 	conn := GetConnection()
-	challenges, err := conn.GetAllChallenges(showInactive)
-	if err != nil {
-		return []Challenge{}, err
-	}
-
-	return challenges, nil
+	return conn.GetAllChallenges(showInactive)
 }
 
 func GetChallengeByID(id uint) (Challenge, error) {

--- a/src/models/db.go
+++ b/src/models/db.go
@@ -16,6 +16,10 @@ type DatabaseInterface interface {
 	GetPointsForUser(userId uint) (uint, error)
 	GetLeaderboard() ([]types.LeaderboardEntry, error)
 	GetGallery() ([]types.GalleryItem, error)
+	HasSubmissions(challengeId uint) (bool, error)
+	UpdateChallenge(challengeId Challenge, updateChallengeRequest types.UpdateChallengeRequest) (Challenge, error)
+	UpdateAnswer(challengeId uint, answer string) (Answer, error)
+	DeleteAnswer(challengeId uint) error
 	GetError() error
 }
 

--- a/src/models/db_mock.go
+++ b/src/models/db_mock.go
@@ -118,6 +118,54 @@ func (m *MockDB) GetGallery() ([]types.GalleryItem, error) {
 	}, nil
 }
 
+func (m *MockDB) GetChallengeByID(id uint) (Challenge, error) {
+	if m.Error != nil {
+		return Challenge{}, apperrors.NewDatabaseError(m.Error.Error())
+	}
+
+	return Challenge{
+		ID:          id,
+		Name:        "Challenge",
+		Description: "Description",
+		Points:      100,
+		Image:       "https://example.com/image.jpg",
+		Status:      "active",
+		Type:        "upload_photo",
+	}, nil
+}
+
+func (m *MockDB) HasSubmissions(_ uint) (bool, error) {
+	if m.Error != nil {
+		return false, apperrors.NewDatabaseError(m.Error.Error())
+	}
+
+	return true, nil
+}
+
+func (m *MockDB) UpdateChallenge(_ Challenge, _ types.UpdateChallengeRequest) (Challenge, error) {
+	if m.Error != nil {
+		return Challenge{}, apperrors.NewDatabaseError(m.Error.Error())
+	}
+
+	return Challenge{}, nil
+}
+
+func (m *MockDB) DeleteAnswer(_ uint) error {
+	if m.Error != nil {
+		return apperrors.NewDatabaseError(m.Error.Error())
+	}
+
+	return nil
+}
+
+func (m *MockDB) UpdateAnswer(_ uint, _ string) (Answer, error) {
+	if m.Error != nil {
+		return Answer{}, apperrors.NewDatabaseError(m.Error.Error())
+	}
+
+	return Answer{}, nil
+}
+
 func (m *MockDB) GetError() error {
 	if m.Error == nil {
 		return nil

--- a/src/routes/challenges.go
+++ b/src/routes/challenges.go
@@ -184,3 +184,36 @@ func VerifyAnswer(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, response)
 	return
 }
+
+func UpdateChallenge(c *gin.Context) {
+	id, editChallengeRequest, err := validators.ValidateUpdateChallengeRequest(c)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	challenge, err := models.GetChallengeByID(id)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	challenge, err = challenge.Update(editChallengeRequest)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	response := types.UpdateChallengeResponse{
+		Id:          challenge.ID,
+		Name:        challenge.Name,
+		Description: challenge.Description,
+		Points:      challenge.Points,
+		Image:       challenge.Image,
+		Status:      challenge.Status,
+		Type:        challenge.Type,
+	}
+
+	c.IndentedJSON(http.StatusOK, response)
+	return
+}

--- a/src/routes/router.go
+++ b/src/routes/router.go
@@ -20,6 +20,7 @@ func GetRouter() *gin.Engine {
 	router.POST("/challenges", middleware.IsAdmin, CreateChallenge)
 	router.GET("/challenges", middleware.IsLoggedIn, GetAllChallenges)
 	router.POST("/challenges/:id/verify", middleware.IsLoggedIn, VerifyAnswer)
+	router.PUT("/challenges/:id", middleware.IsAdmin, UpdateChallenge)
 
 	router.POST("/auth/login", Login)
 	router.GET("/auth/current-user", GetCurrentUser)

--- a/src/types/challenges.go
+++ b/src/types/challenges.go
@@ -69,3 +69,23 @@ type GetChallengeAdminResponse struct {
 	Status      ChallengeStatus `json:"status"`
 	Type        ChallengeType   `json:"type"`
 }
+
+type UpdateChallengeRequest struct {
+	Name        string          `json:"name" validate:"required,min=4"`
+	Description string          `json:"description" validate:"required,min=9"`
+	Points      uint            `json:"points" validate:"required,gte=0"`
+	Image       string          `json:"image" validate:"required,url"`
+	Status      ChallengeStatus `json:"status" validate:"required,oneof=ACTIVE INACTIVE"`
+	Type        ChallengeType   `json:"type" validate:"required,oneof=UPLOAD_PHOTO ANSWER_QUESTION"`
+	Answer      string          `json:"answer" validate:"required_if=Type ANSWER_QUESTION"`
+}
+
+type UpdateChallengeResponse struct {
+	Id          uint            `json:"id"`
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Points      uint            `json:"points"`
+	Image       string          `json:"image"`
+	Status      ChallengeStatus `json:"status"`
+	Type        ChallengeType   `json:"type"`
+}


### PR DESCRIPTION
Fixes: https://github.com/the-wedding-game/the-wedding-game-api/issues/49

This pull request introduces several new functionalities and improvements to the challenge and answer management system. The most important changes include adding validation for updating challenges, implementing update and delete operations for answers, and enhancing the database interface and mock implementations to support these operations.

### Validation and Request Handling:
* Added `ValidateUpdateChallengeRequest` function to validate incoming update requests for challenges in `src/middleware/validators/challenges.go`.

### Challenge and Answer Model Enhancements:
* Introduced `Update` and `DeleteAnswer` methods to the `Answer` model in `src/models/answers.go`.
* Added `Update` method to the `Challenge` model to handle updates, including validation for existing submissions in `src/models/challenges.go`.

### Database Interface and Mock Updates:
* Expanded the `DatabaseInterface` with methods to update and delete answers, and to check for submissions in `src/models/db.go`.
* Updated the mock database implementation to support the new methods in `src/models/db_mock.go` [[1]](diffhunk://#diff-77a39e08e7fad5f916b2ba7fcb027c5bc1b544327306872efadc2041e2370874R13) [[2]](diffhunk://#diff-77a39e08e7fad5f916b2ba7fcb027c5bc1b544327306872efadc2041e2370874R122-R193) [[3]](diffhunk://#diff-77a39e08e7fad5f916b2ba7fcb027c5bc1b544327306872efadc2041e2370874R205-R213).

### Test Coverage:
* Added comprehensive tests for new functionalities, including updating and deleting answers, and handling challenge updates with and without existing submissions in `src/models/answers_test.go` [[1]](diffhunk://#diff-f26652df0cefa552739a0db0e4161006cb82757002c838e8b9e8bfb76dac4945R12) [[2]](diffhunk://#diff-f26652df0cefa552739a0db0e4161006cb82757002c838e8b9e8bfb76dac4945R162-R300) and `src/models/challenges_test.go` [[3]](diffhunk://#diff-8344ad43c1641e9167fcd6b3001e38665af91352dafc6a1322862814ad0d6d84R446-R710).

### Route Handling:
* Implemented `UpdateChallenge` route handler to process challenge update requests in `src/routes/challenges.go`.