### PR TITLE
Make answer field not required in updating challenge

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,0 @@
-sonar.exclusions=**/*_test.go

--- a/src/integration_tests/challenges_test.go
+++ b/src/integration_tests/challenges_test.go
@@ -2150,7 +2150,7 @@ func TestUpdateChallengeWithMissingAnswerQuestionChallengeAnswer(t *testing.T) {
 		t.Errorf("Expected status code 400, got %v", statusCode)
 	}
 
-	if responseBody != "{\"message\":\"Answer cannot be empty\",\"status\":\"error\"}" {
+	if responseBody != "{\"message\":\"Answer cannot be empty when changing to AnswerQuestion challenge type\",\"status\":\"error\"}" {
 		t.Errorf("Expected response Bad Request, got %v", responseBody)
 	}
 
@@ -2281,7 +2281,7 @@ func TestUpdateChallengeWithEmptyAnswerQuestionChallengeAnswer(t *testing.T) {
 		t.Errorf("Expected status code 400, got %v", statusCode)
 	}
 
-	if responseBody != "{\"message\":\"Answer cannot be empty\",\"status\":\"error\"}" {
+	if responseBody != "{\"message\":\"Answer cannot be empty when changing to AnswerQuestion challenge type\",\"status\":\"error\"}" {
 		t.Errorf("Expected response Bad Request, got %v", responseBody)
 	}
 }

--- a/src/integration_tests/challenges_test.go
+++ b/src/integration_tests/challenges_test.go
@@ -2122,6 +2122,20 @@ func TestUpdateChallengeWithMissingAnswerQuestionChallengeAnswer(t *testing.T) {
 		return
 	}
 
+	challenge := models.Challenge{
+		Name:        "test_challenge",
+		Description: "test_description",
+		Points:      10,
+		Image:       "test_image",
+		Type:        types.UploadPhotoChallenge,
+		Status:      types.ActiveChallenge,
+	}
+	challenge, err = challenge.Save()
+	if err != nil {
+		t.Errorf("Error saving challenge: %v", err)
+		return
+	}
+
 	updateChallengeRequest := map[string]interface{}{
 		"name":        "updated_name",
 		"description": "updated_description",
@@ -2130,15 +2144,16 @@ func TestUpdateChallengeWithMissingAnswerQuestionChallengeAnswer(t *testing.T) {
 		"type":        types.AnswerQuestionChallenge,
 		"status":      types.InactiveChallenge,
 	}
-	statusCode, responseBody := makeRequestWithToken("PUT", "/challenges/1", updateChallengeRequest, accessToken.Token)
+	statusCode, responseBody := makeRequestWithToken("PUT", "/challenges/"+strconv.Itoa(int(challenge.ID)), updateChallengeRequest, accessToken.Token)
 
 	if statusCode != http.StatusBadRequest {
 		t.Errorf("Expected status code 400, got %v", statusCode)
 	}
 
-	if responseBody != "{\"message\":\"Key: 'UpdateChallengeRequest.Answer' Error:Field validation for 'Answer' failed on the 'required_if' tag\",\"status\":\"error\"}" {
+	if responseBody != "{\"message\":\"Answer cannot be empty\",\"status\":\"error\"}" {
 		t.Errorf("Expected response Bad Request, got %v", responseBody)
 	}
+
 }
 
 func TestUpdateChallengeWithEmptyName(t *testing.T) {
@@ -2237,6 +2252,20 @@ func TestUpdateChallengeWithEmptyAnswerQuestionChallengeAnswer(t *testing.T) {
 		return
 	}
 
+	challenge := models.Challenge{
+		Name:        "test_challenge",
+		Description: "test_description",
+		Points:      10,
+		Image:       "test_image",
+		Type:        types.UploadPhotoChallenge,
+		Status:      types.ActiveChallenge,
+	}
+	challenge, err = challenge.Save()
+	if err != nil {
+		t.Errorf("Error saving challenge: %v", err)
+		return
+	}
+
 	updateChallengeRequest := map[string]interface{}{
 		"name":        "updated_name",
 		"description": "updated_description",
@@ -2246,13 +2275,13 @@ func TestUpdateChallengeWithEmptyAnswerQuestionChallengeAnswer(t *testing.T) {
 		"status":      types.InactiveChallenge,
 		"answer":      "",
 	}
-	statusCode, responseBody := makeRequestWithToken("PUT", "/challenges/1", updateChallengeRequest, accessToken.Token)
+	statusCode, responseBody := makeRequestWithToken("PUT", "/challenges/"+strconv.Itoa(int(challenge.ID)), updateChallengeRequest, accessToken.Token)
 
 	if statusCode != http.StatusBadRequest {
 		t.Errorf("Expected status code 400, got %v", statusCode)
 	}
 
-	if responseBody != "{\"message\":\"Key: 'UpdateChallengeRequest.Answer' Error:Field validation for 'Answer' failed on the 'required_if' tag\",\"status\":\"error\"}" {
+	if responseBody != "{\"message\":\"Answer cannot be empty\",\"status\":\"error\"}" {
 		t.Errorf("Expected response Bad Request, got %v", responseBody)
 	}
 }
@@ -2500,7 +2529,7 @@ func TestUpdateChallengeUpdateAnswerButSubmissionsExistAnswerDoesNotExist(t *tes
 		t.Errorf("Expected status code 404, got %v", statusCode)
 	}
 
-	expectedResponse := "{\"message\":\"error verifying answer: Answer with Challenge with key 26 not found.\",\"status\":\"error\"}"
+	expectedResponse := "{\"message\":\"error verifying answer: Answer with Challenge with key " + strconv.Itoa(int(challenge.ID)) + " not found.\",\"status\":\"error\"}"
 	if responseBody != expectedResponse {
 		t.Errorf("Expected response %v, got %v", expectedResponse, responseBody)
 	}

--- a/src/models/challenges.go
+++ b/src/models/challenges.go
@@ -137,17 +137,22 @@ func (challenge Challenge) checkForInvalidUpdateFields(updateChallengeRequest ty
 }
 
 func (challenge Challenge) updateUnderlyingAnswer(oldType types.ChallengeType, answer string) error {
-	if challenge.Type == types.AnswerQuestionChallenge && answer != "" {
-		answer := NewAnswer(challenge.ID, answer)
+	if challenge.Type == types.AnswerQuestionChallenge {
 
 		// If challenge was previously an AnswerQuestionChallenge, update the answer
-		if oldType == types.AnswerQuestionChallenge {
+		if oldType == types.AnswerQuestionChallenge && answer != "" {
+			answer := NewAnswer(challenge.ID, answer)
 			_, err := answer.Update()
 			if err != nil {
 				return fmt.Errorf("error while updating answer for challenge: %w", err)
 			}
 		} else {
 			// If challenge was previously an UploadPhotoChallenge, create a new answer
+			if answer == "" {
+				return apperrors.NewValidationError("Answer cannot be empty")
+			}
+
+			answer := NewAnswer(challenge.ID, answer)
 			_, err := answer.Save()
 			if err != nil {
 				return fmt.Errorf("error while creating answer for challenge: %w", err)

--- a/src/models/challenges.go
+++ b/src/models/challenges.go
@@ -133,30 +133,17 @@ func (challenge Challenge) checkForInvalidUpdateFields(updateChallengeRequest ty
 		}
 	}
 
+	if challenge.Type == types.UploadPhotoChallenge && updateChallengeRequest.Type == types.AnswerQuestionChallenge && updateChallengeRequest.Answer == "" {
+		return apperrors.NewValidationError("Answer cannot be empty when changing to AnswerQuestion challenge type")
+	}
+
 	return nil
 }
 
 func (challenge Challenge) updateUnderlyingAnswer(oldType types.ChallengeType, answer string) error {
 	if challenge.Type == types.AnswerQuestionChallenge {
-
-		// If challenge was previously an AnswerQuestionChallenge, update the answer
-		if oldType == types.AnswerQuestionChallenge && answer != "" {
-			answer := NewAnswer(challenge.ID, answer)
-			_, err := answer.Update()
-			if err != nil {
-				return fmt.Errorf("error while updating answer for challenge: %w", err)
-			}
-		} else {
-			// If challenge was previously an UploadPhotoChallenge, create a new answer
-			if answer == "" {
-				return apperrors.NewValidationError("Answer cannot be empty")
-			}
-
-			answer := NewAnswer(challenge.ID, answer)
-			_, err := answer.Save()
-			if err != nil {
-				return fmt.Errorf("error while creating answer for challenge: %w", err)
-			}
+		if err := challenge.createOrUpdateAnswer(oldType, answer); err != nil {
+			return fmt.Errorf("error while creating or updating answer: %w", err)
 		}
 	}
 
@@ -164,6 +151,26 @@ func (challenge Challenge) updateUnderlyingAnswer(oldType types.ChallengeType, a
 	if challenge.Type == types.UploadPhotoChallenge && oldType == types.AnswerQuestionChallenge {
 		if err := DeleteAnswer(challenge.ID); err != nil {
 			return err
+		}
+	}
+
+	return nil
+}
+
+func (challenge Challenge) createOrUpdateAnswer(oldType types.ChallengeType, answer string) error {
+	// If challenge was previously an answer question challenge, update the answer
+	if oldType == types.AnswerQuestionChallenge && answer != "" {
+		answer := NewAnswer(challenge.ID, answer)
+		_, err := answer.Update()
+		if err != nil {
+			return fmt.Errorf("error while updating answer for challenge: %w", err)
+		}
+	} else {
+		// If challenge was previously an UploadPhotoChallenge, create a new answer
+		answer := NewAnswer(challenge.ID, answer)
+		_, err := answer.Save()
+		if err != nil {
+			return fmt.Errorf("error while creating answer for challenge: %w", err)
 		}
 	}
 

--- a/src/models/gorm_db.go
+++ b/src/models/gorm_db.go
@@ -57,12 +57,14 @@ func (p *database) GetAllChallenges(showInactive bool) ([]Challenge, error) {
 		p.db = p.db.Raw(`
 			SELECT ID, Name, Description, Points, Image, Type, Status
 			FROM challenges
+			ORDER BY ID 
 		`).Scan(&challenges)
 	} else {
 		p.db = p.db.Raw(`
 			SELECT ID, Name, Description, Points, Image, Type, Status
 			FROM challenges
 			WHERE status = ?
+			ORDER BY ID 
 		`, types.ActiveChallenge).Scan(&challenges)
 	}
 

--- a/src/types/challenges.go
+++ b/src/types/challenges.go
@@ -77,7 +77,7 @@ type UpdateChallengeRequest struct {
 	Image       string          `json:"image" validate:"required,url"`
 	Status      ChallengeStatus `json:"status" validate:"required,oneof=ACTIVE INACTIVE"`
 	Type        ChallengeType   `json:"type" validate:"required,oneof=UPLOAD_PHOTO ANSWER_QUESTION"`
-	Answer      string          `json:"answer" validate:"required_if=Type ANSWER_QUESTION"`
+	Answer      string          `json:"answer"`
 }
 
 type UpdateChallengeResponse struct {


### PR DESCRIPTION
Fixes: https://github.com/the-wedding-game/the-wedding-game-api/issues/53

This pull request includes various changes to improve the validation and handling of challenges in the codebase, as well as some minor adjustments. The most important changes include updating test cases to dynamically use the challenge ID, modifying the `updateUnderlyingAnswer` method to ensure the answer is not empty, and altering the `UpdateChallengeRequest` struct to remove the `required_if` validation for the answer field.

### Test Case Improvements:
* [`src/integration_tests/challenges_test.go`](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eR2125-R2138): Updated test cases to dynamically use the challenge ID instead of hardcoding it, ensuring more robust and flexible tests. [[1]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eR2125-R2138) [[2]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL2133-R2156) [[3]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eR2255-R2268) [[4]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL2249-R2284) [[5]](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eL2503-R2532)

### Validation Enhancements:
* [`src/models/challenges.go`](diffhunk://#diff-dd1235831d9796be9dc3293d92ab96291e7b9c42042bbb29e3a7ba67ab9ae2c4L140-R155): Modified the `updateUnderlyingAnswer` method to ensure the answer is not empty when creating a new answer for a challenge.

### Struct Adjustments:
* [`src/types/challenges.go`](diffhunk://#diff-caa4dea85de27f44a8ba4498682a662fee6788ff8499df727f42525c2ff70370L80-R80): Removed the `required_if` validation for the `Answer` field in the `UpdateChallengeRequest` struct, simplifying the validation logic.

### Minor Adjustments:
* [`src/models/gorm_db.go`](diffhunk://#diff-8dcc0799f551d7084afa1c197dc4587d764a86e249404485d7198067e4925917R60-R67): Added an `ORDER BY ID` clause to the `GetAllChallenges` query to ensure consistent ordering of results.

### Configuration Changes:
* [`sonar-project.properties`](diffhunk://#diff-43ed9d31bea2a6d518d69836bcd1a8e6bd81bf4df96c4745792c220ca5aa549cL1): Removed the exclusion of test files from SonarQube analysis.