### PR TITLE
Add endpoint to retrieve the submissions for a challenge

### DIFF
--- a/src/integration_tests/challenges_test.go
+++ b/src/integration_tests/challenges_test.go
@@ -2825,3 +2825,48 @@ func TestUpdateChallengeAnswerToUpload(t *testing.T) {
 		return
 	}
 }
+
+func TestUpdateChallengeUploadToAnswerNoAnswer(t *testing.T) {
+	models.ResetConnection()
+	deleteAllChallenges()
+
+	_, accessToken, err := createAdminAndGetAccessToken()
+	if err != nil {
+		t.Errorf("Error creating user and getting access token")
+		return
+	}
+
+	challenge := models.Challenge{
+		Name:        "test_challenge",
+		Description: "test_description",
+		Points:      10,
+		Image:       "test_image",
+		Type:        types.UploadPhotoChallenge,
+		Status:      types.ActiveChallenge,
+	}
+	challenge, err = challenge.Save()
+	if err != nil {
+		t.Errorf("Error saving challenge: %v", err)
+		return
+	}
+
+	updateChallengeRequest := types.UpdateChallengeRequest{
+		Name:        "updated_name",
+		Description: "updated_description",
+		Points:      20,
+		Image:       "https://example.com/image.jpg",
+		Type:        types.AnswerQuestionChallenge,
+		Status:      types.InactiveChallenge,
+	}
+
+	statusCode, responseBody := makeRequestWithToken("PUT", "/challenges/"+strconv.Itoa(int(challenge.ID)), updateChallengeRequest, accessToken.Token)
+	if statusCode != http.StatusBadRequest {
+		t.Errorf("Expected status code 200, got %v", statusCode)
+	}
+
+	expectedResponse := "{\"message\":\"Answer cannot be empty when changing to AnswerQuestion challenge type\",\"status\":\"error\"}"
+	if responseBody != expectedResponse {
+		t.Errorf("Expected response %v, got %v", expectedResponse, responseBody)
+		return
+	}
+}

--- a/src/integration_tests/challenges_test.go
+++ b/src/integration_tests/challenges_test.go
@@ -2860,7 +2860,7 @@ func TestUpdateChallengeUploadToAnswerNoAnswer(t *testing.T) {
 
 	statusCode, responseBody := makeRequestWithToken("PUT", "/challenges/"+strconv.Itoa(int(challenge.ID)), updateChallengeRequest, accessToken.Token)
 	if statusCode != http.StatusBadRequest {
-		t.Errorf("Expected status code 200, got %v", statusCode)
+		t.Errorf("Expected status code 400, got %v", statusCode)
 	}
 
 	expectedResponse := "{\"message\":\"Answer cannot be empty when changing to AnswerQuestion challenge type\",\"status\":\"error\"}"

--- a/src/integration_tests/helpers_test.go
+++ b/src/integration_tests/helpers_test.go
@@ -71,6 +71,9 @@ func deleteAllChallenges() {
 		log.Fatalf("Error connecting to database: %v", err)
 	}
 
+	db, _ := database.DB()
+	defer db.Close()
+
 	database.Exec(`DELETE FROM answers`)
 	database.Exec(`DELETE FROM submissions`)
 	database.Exec(`DELETE FROM challenges`)

--- a/src/integration_tests/helpers_test.go
+++ b/src/integration_tests/helpers_test.go
@@ -80,6 +80,29 @@ func deleteAllChallenges() {
 	}
 }
 
+func dropSubmissionsTable() {
+	dbURI := fmt.Sprintf("host=%s port=%s user=%s dbname=%s sslmode=disable password=%s",
+		os.Getenv("DB_HOST"),
+		os.Getenv("DB_PORT"),
+		os.Getenv("DB_USER"),
+		os.Getenv("DB_NAME"),
+		os.Getenv("DB_PASS"),
+	)
+
+	database, err := gorm.Open(postgres.Open(dbURI))
+	if err != nil {
+		log.Fatalf("Error connecting to database: %v", err)
+	}
+	db, _ := database.DB()
+	defer db.Close()
+
+	database.Exec(`DROP TABLE IF EXISTS submissions`)
+
+	if database.Error != nil {
+		log.Fatalf("Error dropping submissions table: %v", database.Error)
+	}
+}
+
 func makeRequest(method string, path string, bodyObj interface{}) (int, string) {
 	body, err := json.Marshal(bodyObj)
 	if err != nil {

--- a/src/integration_tests/setup_test.go
+++ b/src/integration_tests/setup_test.go
@@ -63,6 +63,9 @@ func setupTestDb() {
 	ready := false
 	for i := 0; i < 10; i++ {
 		db, err := gorm.Open(postgres.Open(dbURI))
+		conn, _ := db.DB()
+		defer conn.Close()
+
 		if err == nil {
 			ready = true
 			log.Println("Database is ready!")

--- a/src/middleware/validators/challenges.go
+++ b/src/middleware/validators/challenges.go
@@ -91,3 +91,12 @@ func ValidateVerifyAnswerRequest(c *gin.Context) (uint, types.VerifyAnswerReques
 
 	return uint(id), verifyAnswerRequest, nil
 }
+
+func ValidateGetSubmissionsRequest(c *gin.Context) (uint, error) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return 0, apperrors.NewValidationError(constants.InvalidChallengeIDError)
+	}
+
+	return uint(id), nil
+}

--- a/src/middleware/validators/challenges_test.go
+++ b/src/middleware/validators/challenges_test.go
@@ -967,3 +967,50 @@ func TestValidateVerifyAnswerRequestWithMissingAnswer(t *testing.T) {
 		t.Error("Expected error message to be", expectedError, "got", err.Error())
 	}
 }
+
+func TestValidateGetSubmissionsRequest(t *testing.T) {
+	params := map[string]string{"id": "1"}
+	c := generateRequestWithParamsOnly(params)
+
+	id, err := ValidateGetSubmissionsRequest(c)
+	if err != nil {
+		t.Error("Expected no error, got", err)
+		return
+	}
+
+	if id != 1 {
+		t.Error("Expected id to be 1, got", id)
+	}
+}
+
+func TestValidateGetSubmissionsRequestWithEmptyParams(t *testing.T) {
+	params := map[string]string{}
+	c := generateRequestWithParamsOnly(params)
+
+	_, err := ValidateGetSubmissionsRequest(c)
+	if err == nil {
+		t.Error("Expected error, got nil")
+		return
+	}
+
+	expectedError := "invalid challenge id"
+	if err.Error() != expectedError {
+		t.Error("Expected error message to be", expectedError, "got", err.Error())
+	}
+}
+
+func TestValidateGetSubmissionsRequestWithInvalidId(t *testing.T) {
+	params := map[string]string{"id": "invalid"}
+	c := generateRequestWithParamsOnly(params)
+
+	_, err := ValidateGetSubmissionsRequest(c)
+	if err == nil {
+		t.Error("Expected error, got nil")
+		return
+	}
+
+	expectedError := "invalid challenge id"
+	if err.Error() != expectedError {
+		t.Error("Expected error message to be", expectedError, "got", err.Error())
+	}
+}

--- a/src/models/challenges.go
+++ b/src/models/challenges.go
@@ -165,7 +165,9 @@ func (challenge Challenge) createOrUpdateAnswer(oldType types.ChallengeType, ans
 		if err != nil {
 			return fmt.Errorf("error while updating answer for challenge: %w", err)
 		}
-	} else {
+	}
+
+	if oldType == types.UploadPhotoChallenge {
 		// If challenge was previously an UploadPhotoChallenge, create a new answer
 		answer := NewAnswer(challenge.ID, answer)
 		_, err := answer.Save()

--- a/src/models/challenges_test.go
+++ b/src/models/challenges_test.go
@@ -708,3 +708,42 @@ func TestUpdateChallengeWithSubmissionsButSameAnswer(t *testing.T) {
 		t.Errorf("expected ACTIVE_CHALLENGE but got %s", updatedChallenge.Status)
 	}
 }
+
+func TestUpdateChallengeUploadToAnswerNoAnswer(t *testing.T) {
+	SetupMockDb()
+
+	createChallengeRequest := types.CreateChallengeRequest{
+		Name:        testChallenge1.Name,
+		Description: testChallenge1.Description,
+		Points:      testChallenge1.Points,
+		Image:       testChallenge1.Image,
+		Type:        types.UploadPhotoChallenge,
+	}
+
+	challenge, err := CreateNewChallenge(createChallengeRequest)
+	if err != nil {
+		t.Errorf("expected nil but got %s", err.Error())
+		return
+	}
+
+	updateChallengeRequest := types.UpdateChallengeRequest{
+		Name:        "test_challenge_updated",
+		Description: "test_description_updated",
+		Points:      100,
+		Image:       "test_image_updated",
+		Type:        types.AnswerQuestionChallenge,
+		Status:      types.InactiveChallenge,
+	}
+
+	_, err = challenge.Update(updateChallengeRequest)
+	if err == nil {
+		t.Errorf("expected an error")
+		return
+	}
+
+	if err.Error() != "Answer cannot be empty when changing to AnswerQuestion challenge type" {
+		t.Errorf("expected Answer cannot be empty when changing to AnswerQuestion challenge type but got %s", err.Error())
+		return
+	}
+
+}

--- a/src/models/db.go
+++ b/src/models/db.go
@@ -20,6 +20,7 @@ type DatabaseInterface interface {
 	UpdateChallenge(challengeId Challenge, updateChallengeRequest types.UpdateChallengeRequest) (Challenge, error)
 	UpdateAnswer(challengeId uint, answer string) (Answer, error)
 	DeleteAnswer(challengeId uint) error
+	GetSubmissionsForChallenge(challengeId uint) ([]types.SubmissionForChallenge, error)
 	GetError() error
 }
 

--- a/src/models/db_mock.go
+++ b/src/models/db_mock.go
@@ -3,6 +3,7 @@ package models
 import (
 	"errors"
 	"reflect"
+	"strconv"
 	"strings"
 	apperrors "the-wedding-game-api/errors"
 	"the-wedding-game-api/types"
@@ -210,4 +211,26 @@ func (m *MockDB) AddSubmission(submission Submission) (Submission, error) {
 
 	m.submissions = append(m.submissions, submission)
 	return submission, nil
+}
+
+func (m *MockDB) GetSubmissionsForChallenge(challengeId uint) ([]types.SubmissionForChallenge, error) {
+	if m.Error != nil {
+		return nil, apperrors.NewDatabaseError(m.Error.Error())
+	}
+
+	var submissions []types.SubmissionForChallenge
+	for _, submission := range m.submissions {
+		if submission.ChallengeID == challengeId {
+			submissions = append(submissions, types.SubmissionForChallenge{
+				Id:            submission.ID,
+				Answer:        submission.Answer,
+				ChallengeId:   submission.ChallengeID,
+				ChallengeName: "Challenge Name",
+				UserId:        submission.UserID,
+				Username:      "user" + strconv.Itoa(int(submission.UserID)),
+			})
+		}
+	}
+
+	return submissions, nil
 }

--- a/src/models/gorm_db.go
+++ b/src/models/gorm_db.go
@@ -228,6 +228,29 @@ func (p *database) DeleteAnswer(challengeId uint) error {
 	return nil
 }
 
+func (p *database) GetSubmissionsForChallenge(challengeId uint) ([]types.SubmissionForChallenge, error) {
+	var submissions = make([]types.SubmissionForChallenge, 0)
+	tx := p.db.Raw(`
+		SELECT
+		    submissions.id,
+		    submissions.answer,
+		    submissions.challenge_id AS "ChallengeId",
+		    challenges.name AS "ChallengeName",
+		    submissions.user_id AS "UserId",
+		    users.username
+		FROM submissions
+		INNER JOIN users ON submissions.user_id = users.id
+		INNER JOIN challenges ON submissions.challenge_id = challenges.id
+		WHERE challenge_id = ?
+	`, challengeId).Scan(&submissions)
+
+	if tx.Error != nil {
+		return nil, apperrors.NewDatabaseError(tx.Error.Error())
+	}
+
+	return submissions, nil
+}
+
 func (p *database) GetError() error {
 	err := p.db.Error
 	if err == nil {

--- a/src/models/submissions.go
+++ b/src/models/submissions.go
@@ -62,3 +62,13 @@ func GetLeaderboard() ([]types.LeaderboardEntry, error) {
 	}
 	return leaderboard, nil
 }
+
+func GetSubmissionsForChallenge(challengeId uint) ([]types.SubmissionForChallenge, error) {
+	conn := GetConnection()
+	submissions, err := conn.GetSubmissionsForChallenge(challengeId)
+	if err != nil {
+		return nil, err
+	}
+
+	return submissions, nil
+}

--- a/src/models/submissions_test.go
+++ b/src/models/submissions_test.go
@@ -257,3 +257,57 @@ func TestGetLeaderboardError(t *testing.T) {
 		t.Errorf("expected test_error but got %s", err.Error())
 	}
 }
+
+func TestGetSubmissionsForChallenge(t *testing.T) {
+	mockDb := SetupMockDb()
+	_, err1 := mockDb.AddSubmission(testSubmission1)
+	if err1 != nil {
+		t.Errorf("expected nil but got %v", err1)
+		return
+	}
+	_, err2 := mockDb.AddSubmission(testSubmission2)
+	if err2 != nil {
+		t.Errorf("expected nil but got %v", err2)
+		return
+	}
+
+	submissions, err := GetSubmissionsForChallenge(testSubmission1.ChallengeID)
+	if err != nil {
+		t.Errorf("expected nil but got %v", err)
+		return
+	}
+
+	if len(submissions) != 1 {
+		t.Errorf("expected 2 but got %d", len(submissions))
+		return
+	}
+}
+
+func TestGetSubmissionsForChallengeEmpty(t *testing.T) {
+	SetupMockDb()
+
+	submissions, err := GetSubmissionsForChallenge(testSubmission1.ChallengeID)
+	if err != nil {
+		t.Errorf("expected nil but got %v", err)
+		return
+	}
+
+	if len(submissions) != 0 {
+		t.Errorf("expected 0 but got %d", len(submissions))
+	}
+}
+
+func TestGetSubmissionsForChallengeError(t *testing.T) {
+	mockDb := SetupMockDb()
+	mockDb.Error = errors.New("test_error")
+
+	_, err := GetSubmissionsForChallenge(testSubmission1.ChallengeID)
+	if err == nil {
+		t.Errorf("expected error but got nil")
+		return
+	}
+
+	if !apperrors.IsDatabaseError(err) {
+		t.Errorf("expected true but got false")
+	}
+}

--- a/src/models/submissions_test.go
+++ b/src/models/submissions_test.go
@@ -278,7 +278,7 @@ func TestGetSubmissionsForChallenge(t *testing.T) {
 	}
 
 	if len(submissions) != 1 {
-		t.Errorf("expected 2 but got %d", len(submissions))
+		t.Errorf("expected 1 but got %d", len(submissions))
 		return
 	}
 }

--- a/src/routes/challenges.go
+++ b/src/routes/challenges.go
@@ -217,3 +217,23 @@ func UpdateChallenge(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, response)
 	return
 }
+
+func GetSubmissions(c *gin.Context) {
+	challengeId, err := validators.ValidateGetSubmissionsRequest(c)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	submissions, err := models.GetSubmissionsForChallenge(challengeId)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	var response types.GetSubmissionsResponse
+	response.Submissions = submissions
+
+	c.IndentedJSON(http.StatusOK, response)
+	return
+}

--- a/src/routes/router.go
+++ b/src/routes/router.go
@@ -20,6 +20,7 @@ func GetRouter() *gin.Engine {
 	router.POST("/challenges", middleware.IsAdmin, CreateChallenge)
 	router.GET("/challenges", middleware.IsLoggedIn, GetAllChallenges)
 	router.POST("/challenges/:id/verify", middleware.IsLoggedIn, VerifyAnswer)
+	router.GET("/challenges/:id/submissions", middleware.IsLoggedIn, GetSubmissions)
 	router.PUT("/challenges/:id", middleware.IsAdmin, UpdateChallenge)
 
 	router.POST("/auth/login", Login)

--- a/src/types/challenges.go
+++ b/src/types/challenges.go
@@ -89,3 +89,16 @@ type UpdateChallengeResponse struct {
 	Status      ChallengeStatus `json:"status"`
 	Type        ChallengeType   `json:"type"`
 }
+
+type SubmissionForChallenge struct {
+	Id            uint   `json:"id"`
+	Answer        string `json:"answer"`
+	ChallengeId   uint   `json:"challenge_id"`
+	ChallengeName string `json:"challenge_name"`
+	UserId        uint   `json:"user_id"`
+	Username      string `json:"username"`
+}
+
+type GetSubmissionsResponse struct {
+	Submissions []SubmissionForChallenge `json:"submissions"`
+}


### PR DESCRIPTION
Fixes: https://github.com/the-wedding-game/the-wedding-game-api/issues/55

This pull request adds new test cases to ensure that challenges cannot be updated from `UploadPhotoChallenge` to `AnswerQuestionChallenge` without providing an answer. The changes include adding tests in both the integration tests and the model tests.

New test cases added:

* [`src/integration_tests/challenges_test.go`](diffhunk://#diff-2683dbcdb39a4c5e0a5dacbe74ab939e1cf28739906c0d7c455fa5794d9f9b3eR2828-R2872): Added `TestUpdateChallengeUploadToAnswerNoAnswer` to verify that updating a challenge from `UploadPhotoChallenge` to `AnswerQuestionChallenge` without providing an answer returns a `BadRequest` status and the appropriate error message.
* [`src/models/challenges_test.go`](diffhunk://#diff-8344ad43c1641e9167fcd6b3001e38665af91352dafc6a1322862814ad0d6d84R711-R749): Added `TestUpdateChallengeUploadToAnswerNoAnswer` to confirm that attempting to update a challenge from `UploadPhotoChallenge` to `AnswerQuestionChallenge` without an answer results in an error with the expected message.