### PR TITLE
Add admin endpoint to get the answer for a question

### DIFF
--- a/src/integration_tests/helpers_test.go
+++ b/src/integration_tests/helpers_test.go
@@ -106,6 +106,29 @@ func dropSubmissionsTable() {
 	}
 }
 
+func dropAnswersTable() {
+	dbURI := fmt.Sprintf("host=%s port=%s user=%s dbname=%s sslmode=disable password=%s",
+		os.Getenv("DB_HOST"),
+		os.Getenv("DB_PORT"),
+		os.Getenv("DB_USER"),
+		os.Getenv("DB_NAME"),
+		os.Getenv("DB_PASS"),
+	)
+
+	database, err := gorm.Open(postgres.Open(dbURI))
+	if err != nil {
+		log.Fatalf("Error connecting to database: %v", err)
+	}
+	db, _ := database.DB()
+	defer db.Close()
+
+	database.Exec(`DROP TABLE IF EXISTS answers`)
+
+	if database.Error != nil {
+		log.Fatalf("Error dropping answers table: %v", database.Error)
+	}
+}
+
 func makeRequest(method string, path string, bodyObj interface{}) (int, string) {
 	body, err := json.Marshal(bodyObj)
 	if err != nil {

--- a/src/integration_tests/helpers_test.go
+++ b/src/integration_tests/helpers_test.go
@@ -2,6 +2,7 @@ package integrationtests
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"gorm.io/driver/postgres"
@@ -72,11 +73,16 @@ func deleteAllChallenges() {
 	}
 
 	db, _ := database.DB()
-	defer db.Close()
+	defer func(db *sql.DB) {
+		err := db.Close()
+		if err != nil {
+			log.Fatalf("Error closing database connection: %v", err)
+		}
+	}(db)
 
-	database.Exec(`DELETE FROM answers`)
-	database.Exec(`DELETE FROM submissions`)
-	database.Exec(`DELETE FROM challenges`)
+	database.Exec(`DELETE FROM answers WHERE id > 0`)
+	database.Exec(`DELETE FROM submissions WHERE id > 0`)
+	database.Exec(`DELETE FROM challenges WHERE id > 0`)
 
 	if database.Error != nil {
 		log.Fatalf("Error deleting challenges: %v", database.Error)
@@ -97,7 +103,12 @@ func dropSubmissionsTable() {
 		log.Fatalf("Error connecting to database: %v", err)
 	}
 	db, _ := database.DB()
-	defer db.Close()
+	defer func(db *sql.DB) {
+		err := db.Close()
+		if err != nil {
+			log.Fatalf("Error closing database connection: %v", err)
+		}
+	}(db)
 
 	database.Exec(`DROP TABLE IF EXISTS submissions`)
 
@@ -120,7 +131,12 @@ func dropAnswersTable() {
 		log.Fatalf("Error connecting to database: %v", err)
 	}
 	db, _ := database.DB()
-	defer db.Close()
+	defer func(db *sql.DB) {
+		err := db.Close()
+		if err != nil {
+			log.Fatalf("Error closing database connection: %v", err)
+		}
+	}(db)
 
 	database.Exec(`DROP TABLE IF EXISTS answers`)
 

--- a/src/integration_tests/setup_test.go
+++ b/src/integration_tests/setup_test.go
@@ -63,10 +63,11 @@ func setupTestDb() {
 	ready := false
 	for i := 0; i < 10; i++ {
 		db, err := gorm.Open(postgres.Open(dbURI))
-		conn, _ := db.DB()
-		defer conn.Close()
 
 		if err == nil {
+			conn, _ := db.DB()
+			_ = conn.Close()
+
 			ready = true
 			log.Println("Database is ready!")
 			err := db.Migrator().DropTable(&models.User{}, &models.AccessToken{}, &models.Challenge{}, &models.Answer{}, &models.Submission{})

--- a/src/integration_tests/setup_test.go
+++ b/src/integration_tests/setup_test.go
@@ -65,9 +65,6 @@ func setupTestDb() {
 		db, err := gorm.Open(postgres.Open(dbURI))
 
 		if err == nil {
-			conn, _ := db.DB()
-			_ = conn.Close()
-
 			ready = true
 			log.Println("Database is ready!")
 			err := db.Migrator().DropTable(&models.User{}, &models.AccessToken{}, &models.Challenge{}, &models.Answer{}, &models.Submission{})
@@ -81,6 +78,9 @@ func setupTestDb() {
 				panic(err)
 				return
 			}
+
+			conn, _ := db.DB()
+			_ = conn.Close()
 			break
 		}
 		log.Printf("Waiting for database to be ready... (%d/10)", i+1)

--- a/src/middleware/error_handler.go
+++ b/src/middleware/error_handler.go
@@ -16,48 +16,6 @@ func ErrorHandler(c *gin.Context) {
 	if err != nil {
 		handleError(c, err.Err)
 		return
-		//if apperrors.IsAccessTokenNotFoundError(err.Err) || apperrors.IsAuthorizationError(err.Err) {
-		//	c.JSON(http.StatusForbidden, gin.H{
-		//		"status":  "error",
-		//		"message": "access denied",
-		//	})
-		//	c.Abort()
-		//	return
-		//}
-		//
-		//if apperrors.IsAuthenticationError(err.Err) {
-		//	c.JSON(http.StatusUnauthorized, gin.H{
-		//		"status":  "error",
-		//		"message": err.Err.Error(),
-		//	})
-		//	c.Abort()
-		//	return
-		//}
-		//
-		//if apperrors.IsValidationError(err.Err) || strings.Contains(err.Err.Error(), "Error:Field validation for") {
-		//	c.JSON(http.StatusBadRequest, gin.H{
-		//		"status":  "error",
-		//		"message": err.Err.Error(),
-		//	})
-		//	c.Abort()
-		//	return
-		//}
-		//
-		//if apperrors.IsNotFoundError(err.Err) {
-		//	c.JSON(http.StatusNotFound, gin.H{
-		//		"status":  "error",
-		//		"message": err.Err.Error(),
-		//	})
-		//	c.Abort()
-		//	return
-		//}
-		//
-		//log.Println(err)
-		//c.JSON(http.StatusInternalServerError, gin.H{
-		//	"status":  "error",
-		//	"message": "An unexpected error occurred.",
-		//})
-		//c.Abort()
 	}
 }
 
@@ -89,7 +47,7 @@ func handleError(c *gin.Context, err error) {
 		return
 	}
 
-	if apperrors.IsNotFoundError(err) {
+	if apperrors.IsNotFoundError(err) || apperrors.IsRecordNotFoundError(err) {
 		c.JSON(http.StatusNotFound, gin.H{
 			"status":  "error",
 			"message": err.Error(),

--- a/src/middleware/validators/challenges.go
+++ b/src/middleware/validators/challenges.go
@@ -100,3 +100,12 @@ func ValidateGetSubmissionsRequest(c *gin.Context) (uint, error) {
 
 	return uint(id), nil
 }
+
+func ValidateGetAnswerRequest(c *gin.Context) (uint, error) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return 0, apperrors.NewValidationError(constants.InvalidChallengeIDError)
+	}
+
+	return uint(id), nil
+}

--- a/src/middleware/validators/challenges_test.go
+++ b/src/middleware/validators/challenges_test.go
@@ -1014,3 +1014,50 @@ func TestValidateGetSubmissionsRequestWithInvalidId(t *testing.T) {
 		t.Error("Expected error message to be", expectedError, "got", err.Error())
 	}
 }
+
+func TestValidateGetAnswerRequest(t *testing.T) {
+	params := map[string]string{"id": "1"}
+	c := generateRequestWithParamsOnly(params)
+
+	id, err := ValidateGetAnswerRequest(c)
+	if err != nil {
+		t.Error("Expected no error, got", err)
+		return
+	}
+
+	if id != 1 {
+		t.Error("Expected id to be 1, got", id)
+	}
+}
+
+func TestValidateGetAnswerRequestWithEmptyParams(t *testing.T) {
+	params := map[string]string{}
+	c := generateRequestWithParamsOnly(params)
+
+	_, err := ValidateGetAnswerRequest(c)
+	if err == nil {
+		t.Error("Expected error, got nil")
+		return
+	}
+
+	expectedError := "invalid challenge id"
+	if err.Error() != expectedError {
+		t.Error("Expected error message to be", expectedError, "got", err.Error())
+	}
+}
+
+func TestValidateGetAnswerRequestWithInvalidId(t *testing.T) {
+	params := map[string]string{"id": "invalid"}
+	c := generateRequestWithParamsOnly(params)
+
+	_, err := ValidateGetAnswerRequest(c)
+	if err == nil {
+		t.Error("Expected error, got nil")
+		return
+	}
+
+	expectedError := "invalid challenge id"
+	if err.Error() != expectedError {
+		t.Error("Expected error message to be", expectedError, "got", err.Error())
+	}
+}

--- a/src/models/answers.go
+++ b/src/models/answers.go
@@ -86,3 +86,16 @@ func DeleteAnswer(challengeId uint) error {
 	conn := GetConnection()
 	return conn.DeleteAnswer(challengeId)
 }
+
+func GetAnswer(challengeId uint) (string, error) {
+	conn := GetConnection()
+	answer, err := conn.GetAnswerForChallenge(challengeId)
+	if err != nil {
+		if apperrors.IsRecordNotFoundError(err) {
+			return "", apperrors.NewNotFoundError("Answer with Challenge", strconv.Itoa(int(challengeId)))
+		}
+		return "", err
+	}
+
+	return answer, nil
+}

--- a/src/models/answers_test.go
+++ b/src/models/answers_test.go
@@ -298,3 +298,38 @@ func TestDeleteAnswerError(t *testing.T) {
 		t.Errorf("expected test_error but got %s", err.Error())
 	}
 }
+
+func TestGetAnswer(t *testing.T) {
+	SetupMockDb()
+
+	createTestChallenge(testChallenge123)
+	createTestAnswer(testAnswer123)
+
+	answer, err := GetAnswer(testAnswer123.ChallengeID)
+	if err != nil {
+		t.Errorf("expected nil but got %s", err.Error())
+		return
+	}
+
+	if answer != "mock_answer" {
+		t.Errorf("expected %s but got %s", testAnswer123.Value, answer)
+	}
+}
+
+func TestGetAnswerError(t *testing.T) {
+	mockDB := SetupMockDb()
+	mockDB.Error = errors.New("test_error")
+
+	_, err := GetAnswer(testAnswer123.ChallengeID)
+	if err == nil {
+		t.Errorf("expected error but got nil")
+		return
+	}
+
+	if !apperrors.IsDatabaseError(err) {
+		t.Errorf("expected database error but got %s", err.Error())
+	}
+	if err.Error() != "test_error" {
+		t.Errorf("expected test_error but got %s", err.Error())
+	}
+}

--- a/src/models/db.go
+++ b/src/models/db.go
@@ -21,6 +21,7 @@ type DatabaseInterface interface {
 	UpdateAnswer(challengeId uint, answer string) (Answer, error)
 	DeleteAnswer(challengeId uint) error
 	GetSubmissionsForChallenge(challengeId uint) ([]types.SubmissionForChallenge, error)
+	GetAnswerForChallenge(challengeId uint) (string, error)
 	GetError() error
 }
 

--- a/src/models/db_mock.go
+++ b/src/models/db_mock.go
@@ -235,7 +235,7 @@ func (m *MockDB) GetSubmissionsForChallenge(challengeId uint) ([]types.Submissio
 	return submissions, nil
 }
 
-func (m *MockDB) GetAnswerForChallenge(challengeId uint) (string, error) {
+func (m *MockDB) GetAnswerForChallenge(_ uint) (string, error) {
 	if m.Error != nil {
 		return "", apperrors.NewDatabaseError(m.Error.Error())
 	}

--- a/src/models/db_mock.go
+++ b/src/models/db_mock.go
@@ -234,3 +234,11 @@ func (m *MockDB) GetSubmissionsForChallenge(challengeId uint) ([]types.Submissio
 
 	return submissions, nil
 }
+
+func (m *MockDB) GetAnswerForChallenge(challengeId uint) (string, error) {
+	if m.Error != nil {
+		return "", apperrors.NewDatabaseError(m.Error.Error())
+	}
+
+	return "mock_answer", nil
+}

--- a/src/models/gorm_db.go
+++ b/src/models/gorm_db.go
@@ -251,6 +251,25 @@ func (p *database) GetSubmissionsForChallenge(challengeId uint) ([]types.Submiss
 	return submissions, nil
 }
 
+func (p *database) GetAnswerForChallenge(challengeId uint) (string, error) {
+	var answer string
+	tx := p.db.Raw(`
+		SELECT value
+		FROM answers
+		WHERE challenge_id = ?
+	`, challengeId).Scan(&answer)
+
+	if tx.Error != nil {
+		return "", apperrors.NewDatabaseError(tx.Error.Error())
+	}
+
+	if tx.RowsAffected == 0 {
+		return "", apperrors.NewRecordNotFoundError(fmt.Sprintf("Answer with Challenge ID %d not found", challengeId))
+	}
+
+	return answer, nil
+}
+
 func (p *database) GetError() error {
 	err := p.db.Error
 	if err == nil {

--- a/src/routes/challenges.go
+++ b/src/routes/challenges.go
@@ -237,3 +237,24 @@ func GetSubmissions(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, response)
 	return
 }
+
+func GetAnswer(c *gin.Context) {
+	challengeId, err := validators.ValidateGetAnswerRequest(c)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	answer, err := models.GetAnswer(challengeId)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	response := types.GetAnswerResponse{
+		Answer: answer,
+	}
+
+	c.IndentedJSON(http.StatusOK, response)
+	return
+}

--- a/src/routes/router.go
+++ b/src/routes/router.go
@@ -22,6 +22,7 @@ func GetRouter() *gin.Engine {
 	router.POST("/challenges/:id/verify", middleware.IsLoggedIn, VerifyAnswer)
 	router.GET("/challenges/:id/submissions", middleware.IsLoggedIn, GetSubmissions)
 	router.PUT("/challenges/:id", middleware.IsAdmin, UpdateChallenge)
+	router.GET("/challenges/:id/answer", middleware.IsAdmin, GetAnswer)
 
 	router.POST("/auth/login", Login)
 	router.GET("/auth/current-user", GetCurrentUser)

--- a/src/types/challenges.go
+++ b/src/types/challenges.go
@@ -102,3 +102,7 @@ type SubmissionForChallenge struct {
 type GetSubmissionsResponse struct {
 	Submissions []SubmissionForChallenge `json:"submissions"`
 }
+
+type GetAnswerResponse struct {
+	Answer string `json:"answer"`
+}


### PR DESCRIPTION
Fixes: https://github.com/the-wedding-game/the-wedding-game-api/issues/57

This pull request introduces several new test cases and functions to improve the handling of challenge answers in the system. It also includes some refactoring and error handling improvements. The most important changes are:

### New Test Cases:
* Added multiple test cases in `src/integration_tests/challenges_test.go` to cover scenarios such as invalid tokens, missing tokens, non-admin access, non-existent challenges, and database errors for the `GetAnswer` endpoint.

### Refactoring and Error Handling:
* Refactored the `deleteAllChallenges` and `dropSubmissionsTable` functions in `src/integration_tests/helpers_test.go` to ensure proper database connection closure with error handling. [[1]](diffhunk://#diff-50c447319b82f9f11db82e53f1d77cbe95ea8a3255eca8ee7a65f6c9c8bbaea3L75-R85) [[2]](diffhunk://#diff-50c447319b82f9f11db82e53f1d77cbe95ea8a3255eca8ee7a65f6c9c8bbaea3L100-R111)
* Added a new `dropAnswersTable` function in `src/integration_tests/helpers_test.go` for dropping the answers table during tests.
* Improved error handling in `src/middleware/error_handler.go` by removing commented-out code and adding a check for `IsRecordNotFoundError` in the `handleError` function. [[1]](diffhunk://#diff-00f60cb3ed9df70184fdbf25454ff11dfb60c688bfb6b5c2c67a1d151855e8b1L19-L60) [[2]](diffhunk://#diff-00f60cb3ed9df70184fdbf25454ff11dfb60c688bfb6b5c2c67a1d151855e8b1L92-R50)

### New Functions:
* Introduced `ValidateGetAnswerRequest` in `src/middleware/validators/challenges.go` to validate the request parameters for getting an answer.
* Added `GetAnswer` function in `src/models/answers.go` to retrieve an answer for a given challenge ID, with appropriate error handling.

### Route and Model Changes:
* Added a new route in `src/routes/router.go` to handle `GET /challenges/:id/answer` requests, accessible only by admins.
* Updated `DatabaseInterface` in `src/models/db.go` to include the `GetAnswerForChallenge` method.

### Database Interaction:
* Implemented `GetAnswerForChallenge` method in both `src/models/db_mock.go` and `src/models/gorm_db.go` to retrieve answers from the database. [[1]](diffhunk://#diff-77a39e08e7fad5f916b2ba7fcb027c5bc1b544327306872efadc2041e2370874R237-R244) [[2]](diffhunk://#diff-8dcc0799f551d7084afa1c197dc4587d764a86e249404485d7198067e4925917R254-R272)