### PR TITLE
Fix points and leaderboard endpoints to exclude inactive challenges

### DIFF
--- a/src/integration_tests/helpers_test.go
+++ b/src/integration_tests/helpers_test.go
@@ -298,6 +298,24 @@ func createChallengeWithPoints(points uint) (models.Challenge, error) {
 	return challenge, nil
 }
 
+func createInactiveChallengeWithPoints(points uint) (models.Challenge, error) {
+	challenge := models.Challenge{
+		Name:        "test_challenge",
+		Description: "test_description",
+		Points:      points,
+		Image:       "test_image",
+		Type:        types.UploadPhotoChallenge,
+		Status:      types.InactiveChallenge,
+	}
+
+	challenge, err := challenge.Save()
+	if err != nil {
+		return models.Challenge{}, err
+	}
+
+	return challenge, nil
+}
+
 func completeChallenge(challengeID uint, userID uint) error {
 	submission := models.Submission{
 		ChallengeID: challengeID,

--- a/src/models/gorm_db.go
+++ b/src/models/gorm_db.go
@@ -77,9 +77,9 @@ func (p *database) GetPointsForUser(userId uint) (uint, error) {
 		SELECT SUM(challenges.points) AS points
 		FROM submissions
 		INNER JOIN challenges ON submissions.challenge_id = challenges.id
-		WHERE submissions.user_id = ?
+		WHERE submissions.user_id = ? AND challenges.status = ?
 		GROUP BY submissions.user_id
-		`, userId).Scan(&points)
+		`, userId, types.ActiveChallenge).Scan(&points)
 
 	if tx.Error != nil {
 		return 0, apperrors.NewDatabaseError(tx.Error.Error())
@@ -95,9 +95,10 @@ func (p *database) GetLeaderboard() ([]types.LeaderboardEntry, error) {
 		FROM submissions
 		INNER JOIN users ON submissions.user_id = users.id
 		INNER JOIN challenges ON submissions.challenge_id = challenges.id
+		WHERE challenges.status = ?
 		GROUP BY users.username
 		ORDER BY points DESC
-		`).Scan(&leaderboard)
+		`, types.ActiveChallenge).Scan(&leaderboard)
 
 	if tx.Error != nil {
 		return nil, apperrors.NewDatabaseError(tx.Error.Error())


### PR DESCRIPTION
Fixes: https://github.com/the-wedding-game/the-wedding-game-api/issues/59

This pull request introduces functionality to handle inactive challenges in the points and leaderboard calculations. The most important changes include the addition of helper functions and test cases, as well as modifications to database queries to filter out inactive challenges.

### New helper functions:
* Added `createInactiveChallengeWithPoints` function to create inactive challenges for testing purposes in `src/integration_tests/helpers_test.go`.

### New test cases:
* Added `TestGetCurrentUserPointsWithInactiveChallenges` to verify that points from inactive challenges are not included in the current user points calculation in `src/integration_tests/points_test.go`.
* Added `TestGetLeaderboardWithInactiveChallenges` to ensure that inactive challenges do not affect the leaderboard in `src/integration_tests/points_test.go`.

### Database query modifications:
* Updated `GetPointsForUser` to exclude points from inactive challenges in `src/models/gorm_db.go`.
* Updated `GetLeaderboard` to filter out inactive challenges in the leaderboard calculation in `src/models/gorm_db.go`.…e tests for inactive challenges