### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
     build-and-test:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/the-wedding-game/the-wedding-game-api/security/code-scanning/4](https://github.com/the-wedding-game/the-wedding-game-api/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the tasks performed in the workflow:
- `contents: read` is sufficient for most steps, such as checking out code and running tests.
- `contents: write` might be required for uploading coverage reports to Codecov if it involves interacting with the repository.
- No other permissions appear necessary based on the provided workflow.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `build-and-test` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
